### PR TITLE
Better Scan Failure Error Messages

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -40,7 +40,13 @@ fn load_spec(spec_path: &String) {
         Err(e) => error(format!("Could't find specification file \"{}\": {}", spec_path, e)),
     }
 
-    let fjr = FormatJobRunner::build(&spec);
+    let fjr_res = FormatJobRunner::build(&spec);
+    if fjr_res.is_err() {
+        error(format!("Error loading specification {}: {}", spec_path, fjr_res.err().unwrap()));
+        return;
+    }
+
+    let fjr = fjr_res.unwrap();
 
     println!("Successfully loaded specification");
 
@@ -78,7 +84,7 @@ fn load_spec(spec_path: &String) {
 
         match fjr.format(&input){
             Ok(res) => println!("{}", res),
-            Err(e) => println!("{}", e),
+            Err(e) => println!("Error formatting {}: {}", target_path, e),
         }
     }
 }

--- a/src/core/fmt/mod.rs
+++ b/src/core/fmt/mod.rs
@@ -1,5 +1,6 @@
 use core::parse::Tree;
 use core::fmt::pattern::*;
+use core::Error;
 use std::collections::HashMap;
 
 mod pattern;
@@ -9,14 +10,19 @@ pub struct Formatter {
 }
 
 impl Formatter {
-    pub fn create(patterns: Vec<PatternPair>) -> Formatter {
+    pub fn create(patterns: Vec<PatternPair>) -> Result<Formatter, Error> {
         let mut pattern_map = HashMap::new();
         for pattern_pair in patterns {
-            pattern_map.insert(pattern_pair.production, generate_pattern(&pattern_pair.pattern[..]));
+            match generate_pattern(&pattern_pair.pattern[..]) {
+                Ok(pattern) => {
+                    pattern_map.insert(pattern_pair.production, pattern);
+                },
+                Err(e) => return Err(e),
+            }
         }
-        return Formatter{
+        Ok(Formatter{
             pattern_map,
-        }
+        })
     }
 
     pub fn format<'a>(&self, parse: &'a Tree) -> String {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,4 +1,28 @@
+use core::scan::ScanningError;
+use std::fmt as stdfmt;
+
 pub mod fmt;
 pub mod parse;
 pub mod scan;
 pub mod spec;
+
+#[derive(Debug)]
+pub enum Error{
+    ScanErr(ScanningError),
+    ParseErr(),
+    Err(String),
+}
+
+impl Error{
+    #[allow(dead_code)]
+    fn fmt(&self, f: &mut stdfmt::Formatter) -> stdfmt::Result {
+        write!(f, "{}", self.to_string())
+    }
+    pub fn to_string(&self) -> String {
+        match self {
+            &Error::ScanErr(ref se) => format!("Failed to scan input: No accepting scans after ({},{}): {}...", se.line, se.character, se.sequence),
+            &Error::ParseErr() => format!("Failed to parse input"),
+            &Error::Err(ref msg) => format!("{}", msg),
+        }
+    }
+}

--- a/src/core/scan/maximal_munch.rs
+++ b/src/core/scan/maximal_munch.rs
@@ -3,6 +3,7 @@ use core::scan::Token;
 use core::scan::State;
 use core::scan::Scanner;
 use core::scan::ScanningError;
+use core::scan::FAIL_SEQUENCE_LENGTH;
 use std::cmp;
 
 pub struct MaximalMunchScanner;
@@ -44,7 +45,7 @@ impl Scanner for MaximalMunchScanner {
             let (r_input, end_state, end_line, end_character) = scan_one(input, &dfa.start, line, character, (input, &dfa.start, line, character), dfa);
             let scanned_chars: &[char] = &input[0..(input.len() - r_input.len())];
             if scanned_chars.is_empty() {
-                let seq_len = cmp::min(r_input.len(), 10);
+                let seq_len = cmp::min(r_input.len(), FAIL_SEQUENCE_LENGTH);
                 let mut sequence: String = String::with_capacity(seq_len);
                 for c in &r_input[..seq_len] {
                     sequence.push(*c);

--- a/src/core/scan/maximal_munch.rs
+++ b/src/core/scan/maximal_munch.rs
@@ -2,41 +2,58 @@ use core::scan::DFA;
 use core::scan::Token;
 use core::scan::State;
 use core::scan::Scanner;
+use core::scan::ScanningError;
+use std::cmp;
 
 pub struct MaximalMunchScanner;
 
 impl Scanner for MaximalMunchScanner {
-    fn scan<'a, 'b>(&self, input: &'a str, dfa: &'b DFA) -> Option<Vec<Token>> {
+    fn scan<'a, 'b>(&self, input: &'a str, dfa: &'b DFA) -> Result<Vec<Token>, ScanningError> {
 
-        fn scan_one<'a, 'b>(input: &'a [char], state: &'b State, backtrack: (&'a [char], &'b State), dfa: &'b DFA) -> (&'a [char], &'b State)
+        fn scan_one<'a, 'b>(input: &'a [char], state: &'b State, line: usize, character: usize, backtrack: (&'a [char], &'b State, usize, usize), dfa: &'b DFA) -> (&'a [char], &'b State, usize, usize)
         {
             if input.is_empty() || !dfa.has_transition(input[0], state) {
                 if dfa.accepts(state) {
-                    return (input, state);
+                    return (input, state, line, character);
                 }
                 return backtrack;
             }
 
+            let (new_line, new_character) = if input[0] == '\n' {
+                (line + 1, 1)
+            } else {
+                (line, character + 1)
+            };
+
             let next_state = dfa.transition(state, input[0]);
             let tail: &[char] = &input[1..];
-            let (r_input, end_state) = scan_one(tail, next_state, (input, state), dfa);
+            let (r_input, end_state, end_line, end_character) = scan_one(tail, next_state, new_line, new_character, (input, state, line, character), dfa);
 
             return if dfa.accepts(end_state) {
-                (r_input, end_state)
+                (r_input, end_state, end_line, end_character)
             } else {
                 backtrack
             }
         }
 
-        fn recur<'a, 'b>(input: &'a [char], accumulator: &'a mut Vec<Token>, dfa: &'b DFA) -> bool {
+        fn recur<'a, 'b>(input: &'a [char], accumulator: &'a mut Vec<Token>, dfa: &'b DFA, line: usize, character: usize) -> Option<ScanningError> {
             if input.is_empty() {
-                return true;
+                return None;
             }
 
-            let (r_input, end_state) = scan_one(input, &dfa.start, (input, &dfa.start), dfa);
+            let (r_input, end_state, end_line, end_character) = scan_one(input, &dfa.start, line, character, (input, &dfa.start, line, character), dfa);
             let scanned_chars: &[char] = &input[0..(input.len() - r_input.len())];
             if scanned_chars.is_empty() {
-                return false;
+                let seq_len = cmp::min(r_input.len(), 10);
+                let mut sequence: String = String::with_capacity(seq_len);
+                for c in &r_input[..seq_len] {
+                    sequence.push(*c);
+                }
+                return Some(ScanningError{
+                    sequence,
+                    line: end_line,
+                    character: end_character,
+                });
             }
 
             let accept_as = dfa.tokenize(end_state);
@@ -48,7 +65,7 @@ impl Scanner for MaximalMunchScanner {
                 accumulator.push(token);
             }
 
-            recur(r_input, accumulator, dfa)
+            recur(r_input, accumulator, dfa, end_line, end_character)
         }
 
         let chars : Vec<char> = input.chars().map(|c| {
@@ -56,11 +73,10 @@ impl Scanner for MaximalMunchScanner {
         }).collect();
 
         let mut tokens: Vec<Token> = vec![];
-        let valid = recur(&chars, &mut tokens, dfa);
-        return if valid {
-            Some(tokens)
-        } else {
-            None
+        let err = recur(&chars, &mut tokens, dfa, 1, 1);
+        match err {
+            Some(se) => Err(se),
+            None => Ok(tokens),
         }
     }
 }

--- a/src/core/scan/mod.rs
+++ b/src/core/scan/mod.rs
@@ -10,6 +10,8 @@ pub fn def_scanner() -> Box<Scanner> {
     Box::new(maximal_munch::MaximalMunchScanner)
 }
 
+static FAIL_SEQUENCE_LENGTH: usize = 10;
+
 #[derive(PartialEq, Clone)]
 pub struct Token {
     pub kind: Kind,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ impl FormatJobRunner {
                     None => Err(format!("Failed to parse input")),
                 }
             },
-            Err(se) => Err(format!("Failed to scan input: failed at ({},{}): ...{}...", se.line, se.character, se.sequence)),
+            Err(se) => Err(format!("Failed to scan input: No accepting scans after ({},{}): {}...", se.line, se.character, se.sequence)),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,15 +35,17 @@ impl FormatJobRunner {
         }
     }
 
-    pub fn format(&self, input: &String) -> Result<String, &str> {
-        let tokens = self.scanner.scan(input, &self.dfa);
-        if tokens.is_none() {
-            return Err("Failed to scan input");
-        }
-        let tree = self.parser.parse(tokens.unwrap(), &self.grammar);
-        match tree {
-            Some(parse) => Ok(self.formatter.format(&parse)),
-            None => Err("Failed to parse input"),
+    pub fn format(&self, input: &String) -> Result<String, String> {
+        let res = self.scanner.scan(input, &self.dfa);
+        match res {
+            Ok(tokens) => {
+                let tree = self.parser.parse(tokens, &self.grammar);
+                match tree {
+                    Some(parse) => Ok(self.formatter.format(&parse)),
+                    None => Err(format!("Failed to parse input")),
+                }
+            },
+            Err(se) => Err(format!("Failed to scan input: failed at ({},{}): ...{}...", se.line, se.character, se.sequence)),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ use core::parse::Grammar;
 use core::parse::Parser;
 use core::fmt::Formatter;
 use core::spec;
+use core::Error;
 
 mod core;
 
@@ -22,16 +23,21 @@ pub struct FormatJobRunner {
 }
 
 impl FormatJobRunner {
-    pub fn build(spec: &String) -> FormatJobRunner {
-        let tree = spec::parse_spec(spec);
-        let parse = tree.unwrap();
-        let (dfa, grammar, formatter) = spec::generate_spec(&parse);
-        FormatJobRunner{
-            dfa,
-            grammar,
-            formatter,
-            scanner: scan::def_scanner(),
-            parser: parse::def_parser(),
+    pub fn build(spec: &String) -> Result<FormatJobRunner, String> {
+        match spec::parse_spec(spec) {
+            Ok(parse) => {
+                match spec::generate_spec(&parse) {
+                    Ok((dfa, grammar, formatter)) => Ok(FormatJobRunner {
+                        dfa,
+                        grammar,
+                        formatter,
+                        scanner: scan::def_scanner(),
+                        parser: parse::def_parser(),
+                    }),
+                    Err(e) => Err(e.to_string())
+                }
+            },
+            Err(e) => Err(e.to_string())
         }
     }
 
@@ -42,10 +48,93 @@ impl FormatJobRunner {
                 let tree = self.parser.parse(tokens, &self.grammar);
                 match tree {
                     Some(parse) => Ok(self.formatter.format(&parse)),
-                    None => Err(format!("Failed to parse input")),
+                    None => Err(Error::ParseErr().to_string()),
                 }
             },
-            Err(se) => Err(format!("Failed to scan input: No accepting scans after ({},{}): {}...", se.line, se.character, se.sequence)),
+            Err(se) => Err(Error::ScanErr(se).to_string()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_failed_scan_input() {
+        //setup
+        let spec = "
+'ab'
+
+start 'a' -> ^ACC;
+
+s -> ACC;
+    ".to_string();
+
+        let fjr = FormatJobRunner::build(&spec).unwrap();
+
+        //exercise
+        let res = fjr.format(&"b".to_string());
+
+        //verify
+        assert!(res.is_err());
+        assert_eq!(res.err().unwrap(), "Failed to scan input: No accepting scans after (1,1): b...");
+    }
+
+    #[test]
+    fn test_failed_parse_input() {
+        //setup
+        let spec = "
+'a'
+
+start 'a' -> ^ACC;
+
+s -> B;
+    ".to_string();
+
+        let fjr = FormatJobRunner::build(&spec).unwrap();
+
+        //exercise
+        let res = fjr.format(&"a".to_string());
+
+        //verify
+        assert!(res.is_err());
+        assert_eq!(res.err().unwrap(), "Failed to parse input");
+    }
+
+    #[test]
+    fn test_failed_scan_spec() {
+        //setup
+        let spec = "
+'ab'~
+
+start 'a' -> ^ACC;
+
+s -> ACC;
+    ".to_string();
+
+        //exercise
+        let res = FormatJobRunner::build(&spec);
+
+        //verify
+        assert!(res.is_err());
+        assert_eq!(res.err().unwrap(), "Failed to scan input: No accepting scans after (2,5): ~\n\nstart \'...");
+    }
+
+    #[test]
+    fn test_failed_parse_spec() {
+        //setup
+        let spec = "
+start 'a' -> ^ACC;
+
+s -> B;
+    ".to_string();
+
+        //exercise
+        let res = FormatJobRunner::build(&spec);
+
+        //verify
+        assert!(res.is_err());
+        assert_eq!(res.err().unwrap(), "Failed to parse input");
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -118,6 +118,27 @@ fn test_advanced_operators() {
     assert_eq!(res, "iijijjjijijijiinjiii");
 }
 
+#[test]
+fn test_failed_scan_input() {
+    //setup
+    let spec = "
+'ab'
+
+start 'a' -> ACC;
+
+s -> ACC;
+    ".to_string();
+
+    let fjr = FormatJobRunner::build(&spec);
+
+    //exercise
+    let res = fjr.format(&"b".to_string());
+
+    //verify
+    assert!(res.is_err());
+    assert_eq!(res.err().unwrap(), "Failed to scan input: No accepting scans after (1,1): b...");
+}
+
 fn test_fjr(case_name: &str, spec_name: &str){
     //setup
     let fjr = FormatJobRunner::build(&load_spec(spec_name));

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -29,7 +29,7 @@ s -> acc s `{0}\\n{1}`
 acc -> ACC;
     ".to_string();
 
-    let fjr = FormatJobRunner::build(&spec);
+    let fjr = FormatJobRunner::build(&spec).unwrap();
 
     //exercise
     let res = fjr.format(&"abasdfergrthergerghera".to_string()).unwrap();
@@ -78,7 +78,7 @@ s -> acc s `{0} {1}`
 acc -> ACC;
     ".to_string();
 
-    let fjr = FormatJobRunner::build(&spec);
+    let fjr = FormatJobRunner::build(&spec).unwrap();
 
     //exercise
     let res = fjr.format(&"aaaa \t \n  a aa  aa ".to_string()).unwrap();
@@ -109,7 +109,7 @@ fn test_advanced_operators() {
             -> ID
             -> IN ``;".to_string();
 
-    let fjr = FormatJobRunner::build(&spec);
+    let fjr = FormatJobRunner::build(&spec).unwrap();
 
     //exercise
     let res = fjr.format(&"i ij ijjjijijiji inj in iii".to_string()).unwrap();
@@ -118,30 +118,9 @@ fn test_advanced_operators() {
     assert_eq!(res, "iijijjjijijijiinjiii");
 }
 
-#[test]
-fn test_failed_scan_input() {
-    //setup
-    let spec = "
-'ab'
-
-start 'a' -> ACC;
-
-s -> ACC;
-    ".to_string();
-
-    let fjr = FormatJobRunner::build(&spec);
-
-    //exercise
-    let res = fjr.format(&"b".to_string());
-
-    //verify
-    assert!(res.is_err());
-    assert_eq!(res.err().unwrap(), "Failed to scan input: No accepting scans after (1,1): b...");
-}
-
 fn test_fjr(case_name: &str, spec_name: &str){
     //setup
-    let fjr = FormatJobRunner::build(&load_spec(spec_name));
+    let fjr = FormatJobRunner::build(&load_spec(spec_name)).unwrap();
 
     //exercise
     let res = fjr.format(&load_input(case_name)).unwrap();
@@ -182,7 +161,7 @@ fn assert_matches_file(result: String, file_name: &str){
         Ok(_) => {
             output_file.unwrap().read_to_string(&mut output);
         },
-        Err(e) => {
+        Err(_) => {
             let mut output_file = File::create(&file_path);
             match output_file {
                 Ok(_) => {


### PR DESCRIPTION
- Improved messages when scanning fails, giving line/character number as well as the input that the failed to scan.
- Added basic framework for handling internal parse/scan/format/generic errors and how they get passed up to the library interface.

resolves #4