### PR TITLE
CLI Target File/Directory Specification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,4 +1,12 @@
 [[package]]
+name = "aho-corasick"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -26,6 +34,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "libc"
 version = "0.2.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memchr"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "num"
@@ -98,6 +114,7 @@ name = "padd"
 version = "0.1.0"
 dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "stopwatch 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -112,6 +129,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rustc-serialize"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,6 +160,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "thread_local"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ucd-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
@@ -144,11 +213,13 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
+"checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
+"checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
 "checksum num-bigint 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "81b483ea42927c463e191802e7334556b48e7875297564c0e9951bd3a0ae53e3"
 "checksum num-complex 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656"
@@ -157,8 +228,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num-rational 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "ee314c74bd753fc86b4780aa9475da469155f3848473a261d2d18e35245a784e"
 "checksum num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dee092fcdf725aee04dd7da1d21debff559237d49ef1cb3e69bcb8ece44c7364"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
+"checksum regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "aec3f58d903a7d2a9dc2bf0e41a746f4530e0cab6b615494e058f67a3ef947fb"
+"checksum regex-syntax 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "bd90079345f4a4c3409214734ae220fd773c6f2e8a543d07370c6c1c369cfbfb"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum stopwatch 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "3d04b5ebc78da44d3a456319d8bc2783e7d8cc7ccbb5cb4dc3f54afbd93bf728"
+"checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
+"checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
+"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+"checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ name = "padd"
 [dependencies]
 lazy_static = "1.0"
 stopwatch = "0.0.7"
+regex = "0.2"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,3 +1,6 @@
+extern crate regex;
+
+use self::regex::Regex;
 use padd::FormatJobRunner;
 use std::env;
 use std::io;
@@ -8,6 +11,8 @@ use std::io::SeekFrom;
 use std::process;
 use std::fs::File;
 use std::fs::OpenOptions;
+use std::fs;
+use std::path::Path;
 
 pub fn run(){
     let args: Vec<_> = env::args().collect();
@@ -15,21 +20,6 @@ pub fn run(){
     if args.len() < 2 {
         error("Missing specification file path".to_string());
     }
-
-//    for i in 1..args.len() {
-//        let arg: &String = &args[i];
-//        if arg.starts_with("-") {
-//            match &arg[..] {
-//                "-s" | "--spec" => {
-//                    if args.len() == i + 1 {
-//                        error("Missing specificat*ion file path".to_string());
-//                    }
-//                    load_spec(&args[i + 1]);
-//                },
-//                a => error(format!("Unrecognized parameter {}", a)),
-//            }
-//        }
-//    }
 
     let spec_path = args.get(1).unwrap();
 
@@ -43,21 +33,72 @@ pub fn run(){
 
     println!("Successfully loaded specification");
 
-    loop {
-        let mut target_path = String::new();
+    let mut directory: Option<&Path> = None;
+    let mut file_regex: Option<Regex> = None;
+    let mut target: Option<&Path> = None;
 
-        match io::stdin().read_line(&mut target_path){
-            Ok(_) => {},
-            Err(e) => {
-                println!("Failed to read target file \"{}\": {}", target_path, e);
-                continue;
-            },
+    for i in 2..args.len() {
+        let arg: &String = &args[i];
+        if arg.starts_with("-") {
+            match &arg[..] {
+                "-d" | "--directory" => {
+                    if args.len() == i + 1 {
+                        error("Missing directory path".to_string());
+                    }
+                    directory = Some(Path::new(&args[i + 1]));
+                },
+                "-t" | "--target" => {
+                    if args.len() == i + 1 {
+                        error("Missing target path".to_string());
+                    }
+                    target = Some(Path::new(&args[i + 1]));
+                },
+                "-m" | "--matching" => {
+                    if args.len() == i + 1 {
+                        error("Missing file regex".to_string());
+                    }
+                    match Regex::new(format!(r#"{}"#, &args[i + 1]).as_str()) {
+                        Ok(fn_regex) => file_regex = Some(fn_regex),
+                        Err(e) => error(format!("Failed to build file name regex: {}", e)),
+                    }
+                },
+                a => error(format!("Unrecognized parameter {}", a)),
+            }
         }
-
-        target_path.pop();
-
-        format_file(&target_path, &fjr);
     }
+
+    match target {
+        Some(target_path) => format_file(target_path, &fjr),
+        None => match directory {
+            Some(dir_path) => {
+                let fn_regex = match file_regex {
+                    Some(regex) => regex,
+                    None => Regex::new(r#".*\.rs"#).unwrap(),
+                };
+
+                dir_recur(dir_path, &fn_regex, &fjr)
+            },
+            None => term_loop(&fjr),
+        }
+    }
+}
+
+fn dir_recur(dir_path: &Path, fn_regex: &Regex, fjr: &FormatJobRunner){
+    fs::read_dir(dir_path).unwrap()
+        .for_each(|res| {
+            match res {
+                Ok(dir_item) => {
+                    let path = dir_item.path();
+                    let file_name = path.file_name().unwrap().to_str().unwrap();
+                    if path.is_dir() {
+                        dir_recur(path.as_path(), fn_regex, fjr);
+                    } else if fn_regex.is_match(file_name) {
+                        format_file(path.as_path(), &fjr);
+                    }
+                },
+                Err(e) => println!("An error occurred while searching directory {}: {}", dir_path.to_string_lossy(), e),
+            }
+        });
 }
 
 fn load_spec(spec_path: &String) -> Result<FormatJobRunner, String> {
@@ -73,13 +114,32 @@ fn load_spec(spec_path: &String) -> Result<FormatJobRunner, String> {
                 },
             }
         },
-        Err(e) => error(format!("Could't find specification file \"{}\": {}", spec_path, e)),
+        Err(e) => error(format!("Could't find specification file \"{}\": {}", &spec_path, e)),
     }
 
     FormatJobRunner::build(&spec)
 }
 
-fn format_file(target_path: &String, fjr: &FormatJobRunner){
+fn term_loop(fjr: &FormatJobRunner){
+    loop {
+        let mut target_path = String::new();
+
+        match io::stdin().read_line(&mut target_path){
+            Ok(_) => {},
+            Err(e) => {
+                println!("Failed to read target file \"{}\": {}", target_path, e);
+                continue;
+            },
+        }
+
+        target_path.pop();
+
+        format_file(&Path::new(&target_path), &fjr);
+    }
+}
+
+fn format_file(target_path: &Path, fjr: &FormatJobRunner){
+    println!(">> Formatting {}", target_path.to_string_lossy());
     let target_file = OpenOptions::new().read(true).write(true).open(&target_path);
     match target_file {
         Ok(_) => {
@@ -89,7 +149,7 @@ fn format_file(target_path: &String, fjr: &FormatJobRunner){
             match target.read_to_string(&mut input) {
                 Ok(_) => {},
                 Err(e) => {
-                    println!("Could't read target file \"{}\": {}", &target_path, e);
+                    println!("Could't read target file \"{}\": {}", &target_path.to_string_lossy(), e);
                     return;
                 },
             }
@@ -99,23 +159,23 @@ fn format_file(target_path: &String, fjr: &FormatJobRunner){
                     match target.seek(SeekFrom::Start(0)) {
                         Ok(_) => {},
                         Err(e) => {
-                            println!("Couldn't seek to start of target file \"{}\": {}", &target_path, e);
+                            println!("Couldn't seek to start of target file \"{}\": {}", &target_path.to_string_lossy(), e);
                             return;
                         },
                     }
                     match target.write_all(res.as_bytes()) {
                         Ok(_) => {},
                         Err(e) => {
-                            println!("Couldn't write to target file \"{}\": {}", &target_path, e);
+                            println!("Couldn't write to target file \"{}\": {}", &target_path.to_string_lossy(), e);
                             return;
                         },
                     }
                 },
-                Err(e) => println!("Error formatting {}: {}", &target_path, e),
+                Err(e) => println!("Error formatting {}: {}", &target_path.to_string_lossy(), e),
             }
         },
         Err(e) => {
-            println!("Could't find target file \"{}\": {}", &target_path, e);
+            println!("Could't find target file \"{}\": {}", &target_path.to_string_lossy(), e);
             return;
         },
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -68,12 +68,19 @@ pub fn run(){
     }
 
     match target {
-        Some(target_path) => format_file(target_path, &fjr),
+        Some(target_path) => {
+            if directory.is_some() {
+                error("Invalid arguments: Target file and directory both specified".to_string());
+            } else if file_regex.is_some() {
+                error("Invalid arguments: Target file and file regex both specified".to_string());
+            }
+            format_file(target_path, &fjr)
+        },
         None => match directory {
             Some(dir_path) => {
                 let fn_regex = match file_regex {
                     Some(regex) => regex,
-                    None => Regex::new(r#".*\.rs"#).unwrap(),
+                    None => Regex::new(r#".*"#).unwrap(),
                 };
 
                 dir_recur(dir_path, &fn_regex, &fjr)
@@ -182,7 +189,7 @@ fn format_file(target_path: &Path, fjr: &FormatJobRunner){
 }
 
 fn error(err_text: String){
-    println!("{}", err_text);
+    println!("ERROR: {}", err_text);
     println!("Usage info goes here");
     process::exit(0);
 }

--- a/src/core/parse/earley.rs
+++ b/src/core/parse/earley.rs
@@ -151,7 +151,10 @@ impl Parser for EarleyParser {
 
         let (valid, complete_parses) = partial_parse(chart.len() - 1, grammar, &mut chart);
 
-        println!("FOUND {} COMPLETE PARSE(S)", complete_parses.len());
+        if complete_parses.len() != 1 {
+            println!("WARN: Found {} complete parse(s)", complete_parses.len());
+        }
+
 
         if !valid {
             return None;


### PR DESCRIPTION
Allows cli users to specify a target directory with regex file name matching, or a specific target file when running the command. If neither is specified, the cli will drop into the normal input loop.
resolves #2