### PR TITLE
Patch/multichar lexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,20 +81,15 @@ The specification file:
 
 # dfa
 start
- ' \t\n' -> ws
- '{' -> lbr
- '}' -> rbr;
-ws ^ WHITESPACE
- ' \t\n' -> ws;
-lbr ^ LBRACKET;
-rbr ^ RBRACKET;
+ ' ' | '\t' | '\n' -> ws
+ '{' -> ^LBRACKET
+ '}' -> ^RBRACKET;
+ws ^_;
 
 # grammar
 s -> s b
   ->;
-b -> LBRACKET s RBRACKET `[prefix]{0}\n\n{1;prefix=[prefix]\t}[prefix]{2}\n\n`
-  -> w;
-w -> WHITESPACE ``;
+b -> LBRACKET s RBRACKET `[prefix]{0}\n\n{1;prefix=[prefix]\t}[prefix]{2}\n\n`;
 ```
 The input:
 ```

--- a/src/core/scan/maximal_munch.rs
+++ b/src/core/scan/maximal_munch.rs
@@ -27,7 +27,14 @@ impl Scanner for MaximalMunchScanner {
             };
 
             let next_state = dfa.transition(state, input[0]);
-            let tail: &[char] = &input[1..];
+
+            //TODO remove with CDFA
+            let tail: &[char] = if state.chars().next().unwrap() == '#' && !dfa.td.has_non_def_transition(input[0], state) {
+                input
+            } else {
+                &input[1..]
+            };
+
             let (r_input, end_state, end_line, end_character) = scan_one(tail, next_state, new_line, new_character, (input, state, line, character), dfa);
 
             return if dfa.accepts(end_state) {

--- a/src/core/scan/mod.rs
+++ b/src/core/scan/mod.rs
@@ -55,6 +55,9 @@ impl DFA {
 pub trait TransitionDelta {
     fn transition<'a>(&'a self, state: &'a State, c: char) -> &'a State;
     fn tokenize(&self, state: &State) -> Kind;
+
+    //TODO remove with CDFA
+    fn has_non_def_transition(&self, c: char, state: &State) -> bool;
 }
 
 pub struct CompileTransitionDelta {
@@ -69,6 +72,11 @@ impl TransitionDelta for CompileTransitionDelta {
     }
     fn tokenize(&self, state: &State) -> Kind {
         (self.tokenizer)(&state[..]).to_string()
+    }
+
+    //TODO remove with CDFA
+    fn has_non_def_transition(&self, c: char, state: &State) -> bool {
+        self.transition(state, c) != ""
     }
 }
 
@@ -96,7 +104,7 @@ impl TransitionDelta for RuntimeTransitionDelta {
         match self.delta.get(state) {
             Some(hm) => match hm.get(&c) {
                 Some(s) => s,
-                None => match hm.get(&'_') {
+                None => match hm.get(&'_') { //TODO make default matcher
                     Some(s) => s,
                     None => &NULL_STATE,
                 },
@@ -108,6 +116,17 @@ impl TransitionDelta for RuntimeTransitionDelta {
         match self.tokenizer.get(state) {
             Some(s) => s.clone(),
             None => String::new(),
+        }
+    }
+
+    //TODO remove with CDFA
+    fn has_non_def_transition(&self, c: char, state: &State) -> bool {
+        match self.delta.get(state) {
+            Some(hm) => match hm.get(&c) {
+                Some(_) => true,
+                None => false
+            },
+            None => false,
         }
     }
 }

--- a/src/core/spec.rs
+++ b/src/core/spec.rs
@@ -782,7 +782,7 @@ s -> ;
     ";
 
         let input = "fdkgdfjgdjglkdjglkdjgljbnhbduhoifjeoigjeoghknhkjdfjgoirjt for if endif \
-        elseif somethign eldsfnj hi bob joe here final for fob else if id idhere fobre";
+        elseif somethign eldsfnj hi bob joe here final for fob else if id idhere fobre f ";
 
         let scanner = def_scanner();
         let tree = parse_spec(spec);
@@ -819,7 +819,8 @@ kind=IF lexeme=if
 kind=ID lexeme=id
 kind=ID lexeme=idhere
 kind=FOB lexeme=fob
-kind=ID lexeme=re")
+kind=ID lexeme=re
+kind=ID lexeme=f")
     }
 
     #[test]

--- a/tests/spec/balanced_brackets
+++ b/tests/spec/balanced_brackets
@@ -3,16 +3,11 @@
 # dfa
 start
  ' ' | '\t' | '\n' -> ws
- '{' -> lbr
- '}' -> rbr;
-ws ^ WHITESPACE
- ' ' | '\t' | '\n' -> ws;
-lbr ^ LBRACKET;
-rbr ^ RBRACKET;
+ '{' -> ^LBRACKET
+ '}' -> ^RBRACKET;
+ws ^_;
 
 # grammar
 s -> s b
   ->;
-b -> LBRACKET s RBRACKET `[prefix]{0}\n\n{1;prefix=[prefix]\t}[prefix]{2}\n\n`
-  -> w;
-w -> WHITESPACE ``;
+b -> LBRACKET s RBRACKET `[prefix]{0}\n\n{1;prefix=[prefix]\t}[prefix]{2}\n\n`;

--- a/tests/spec/lacs
+++ b/tests/spec/lacs
@@ -16,45 +16,20 @@ start
     ':' -> ^COLON
     ' ' | '\t' | '\n' -> ws
     '=' -> eq
-    '!' -> ne
+    '!=' -> ^NE
     '<' -> lt
     '>' -> gt
     '/' -> slash
-    '0' -> ^NUM
+    '0' -> num
     '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' -> num
-    'd' -> kd
-    'v' -> kv
-    'I' -> kI
-    'i' -> ki
-    'e' -> ke
+    'def' -> ^DEF
+    'var' -> ^VAR
+    'Int' -> ^INT
+    'if' -> ^IF
+    'else' -> ^ELSE
     _ -> ^ID;
 
-kd      ^ID
-    'e' -> kde;
-kde     ^ID
-    'f' -> ^DEF;
-
-kv      ^ID
-    'a' -> kva;
-kva     ^ID
-    'r' -> ^VAR;
-
-kI      ^ID
-    'n' -> kIn;
-kIn     ^ID
-    't' -> ^INT;
-
-ki      ^ID
-    'f' -> ^IF;
-
-ke      ^ID
-    'l' -> kel;
-kel     ^ID
-    's' -> kels;
-kels    ^ID
-    'e' -> ^ELSE;
-
-ELSE | IF | INT | VAR | DEF | ID | kels | kel | ke | ki | kIn | kI | kva | kv | kde | kd
+ID
     '<' | '>' | '=' | '+' | '-' | '*' | '/' | '%' | '(' | ')' | '{' | '}' | ',' | ';' | ':' | '!' | ' ' | '\n' | '\t' -> fail
     _ -> ID;
 
@@ -71,9 +46,6 @@ comment ^COMMENT
 eq      ^BECOMES
     '=' -> ^EQ
     '>' -> ^ARROW;
-
-ne
-    '=' -> ^NE;
 
 lt      ^LT
     '=' -> ^LE;


### PR DESCRIPTION
Shortened example specifications using new multi-char lexing.
Fixed a bug with default matchers where partial states would consume a character when they should not.
***Technically we are abusing default matcher to behave like epsilon transitions, however this will be properly implemented with CDFAs***