### PR TITLE
Earley Parser Improvements

### DIFF
--- a/src/core/parse/earley.rs
+++ b/src/core/parse/earley.rs
@@ -156,28 +156,12 @@ impl Parser for EarleyParser {
 //        }
 //        println!("-----------------------------------------------------");
 
-        fn partial_parse<'a, 'b>(i: usize, grammar: &'a Grammar, chart: &'b mut Vec<Vec<Item<'a>>>) -> (bool, Vec<Item<'a>>) {
-            //TODO switch to a usize and remove valid
-            let mut complete_parses = vec![];
-            let mut res = false;
-            for j in 0..chart[i].len() {
-                let item = &chart[i][j];
-                if item.rule.lhs == grammar.start && item.next >= item.rule.rhs.len() && item.start == 0 {
-                    complete_parses.push(item.clone());
-                    res = true;
-                }
-            }
-            return (res, complete_parses);
+        fn recognized<'a, 'b>(grammar: &'a Grammar, chart: &'b Vec<Vec<Item<'a>>>) -> bool {
+            chart.last().unwrap().iter()
+                .any(|item| item.rule.lhs == grammar.start && item.next >= item.rule.rhs.len() && item.start == 0)
         }
 
-        let (valid, complete_parses) = partial_parse(chart.len() - 1, grammar, &mut chart);
-
-        //TODO this message is not always correct, depricate or fix
-        if complete_parses.len() != 1 {
-            println!("WARN: Found {} complete parse(s)", complete_parses.len());
-        }
-
-        return if valid {
+        return if recognized(grammar, &chart) {
             Some(parse_tree(grammar, &scan, chart))
         } else {
             None

--- a/src/core/parse/earley.rs
+++ b/src/core/parse/earley.rs
@@ -24,7 +24,6 @@ impl Parser for EarleyParser {
             for rule in &grammar.productions {
                 if rule.rhs.iter().all(|symbol| nss.contains(symbol)) && !nss.contains(&rule.lhs) {
                     nss.insert(rule.lhs.clone());
-                    println!("ADDING NULLABLE: {}", rule.lhs.clone());
                 }
             }
         }
@@ -227,16 +226,6 @@ impl Parser for EarleyParser {
                 }
             }
 
-//            println!("-----------------------------------------------------");
-//            for i in 0..parse_chart.len() {
-//                println!("SET {}", i);
-//                for j in 0..parse_chart[i].len() {
-//                    println!("{}", parse_chart[i][j].to_string());
-//                }
-//                println!();
-//            }
-//            println!("-----------------------------------------------------");
-
             let first_edge = parse_chart[start].iter()
                 .find(|edge| edge.finish == finish && edge.rule.unwrap().lhs == grammar.start);
             match first_edge {
@@ -256,8 +245,6 @@ impl Parser for EarleyParser {
                 } else {
                     let symbol = &symbols[depth];
                     if grammar.terminals.contains(symbol) {
-//                        println!("HIT TERMINAL scan={} symbol={}", scan[node].kind, symbol);
-
                         if scan[node].kind == *symbol {
                             vec![Edge{
                                 rule: None,
@@ -286,10 +273,6 @@ impl Parser for EarleyParser {
                      root: Node)
             -> Option<Vec<(Node, Edge<'a>)>> {
 
-//            println!("-----------------------------------------------------");
-//            println!("STARTING DF_SEARCH AT {}", root);
-//            println!("-----------------------------------------------------");
-
             fn aux<'a>(edges: &Fn(usize, Node) -> Vec<Edge<'a>>,
                        child: &Fn(&Edge) -> Node,
                        leaf: &Fn(usize, Node) -> bool,
@@ -297,15 +280,9 @@ impl Parser for EarleyParser {
                        root: Node)
                 -> Option<Vec<(Node, Edge<'a>)>> {
 
-//                println!("aux at depth={} root={}", depth, root);
-
                 if leaf(depth, root) {
-//                    println!("LEAF");
-
                     Some(vec![])
                 } else {
-//                    println!("NON-LEAF");
-
                     for edge in edges(depth, root) {
                         let mut res = aux(edges, child, leaf, depth + 1, child(&edge));
 

--- a/src/core/parse/earley.rs
+++ b/src/core/parse/earley.rs
@@ -248,19 +248,12 @@ impl Parser for EarleyParser {
                 }
             };
 
-            fn aux<'a>(edges: &Fn(usize, Node) -> Vec<Edge<'a>>,
-                       leaf: &Fn(usize, Node) -> bool,
-                       depth: usize,
-                       root: Node)
-                       -> Option<Vec<(Node, Edge<'a>)>> {
-
+            fn df_search<'a>(edges: &Fn(usize, Node) -> Vec<Edge<'a>>, leaf: &Fn(usize, Node) -> bool, depth: usize, root: Node) -> Option<Vec<(Node, Edge<'a>)>> {
                 if leaf(depth, root) {
                     Some(vec![])
                 } else {
                     for edge in edges(depth, root) {
-                        let mut res = aux(edges, leaf, depth + 1, edge.finish);
-
-                        match res {
+                        match df_search(edges, leaf, depth + 1, edge.finish) {
                             None => {},
                             Some(mut path) => {
                                 path.push((root, edge));
@@ -272,7 +265,7 @@ impl Parser for EarleyParser {
                 }
             }
 
-            match aux(&edges, &leaf, 0, start) {
+            match df_search(&edges, &leaf, 0, start) {
                 None => panic!("Failed to decompose parse edge of recognized scan"),
                 Some(path) => path
             }

--- a/src/core/parse/earley.rs
+++ b/src/core/parse/earley.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use core::parse::Parser;
 use core::parse::Grammar;
 use core::parse::Production;
@@ -9,13 +10,23 @@ pub struct EarleyParser;
 impl Parser for EarleyParser {
     fn parse(&self, scan: Vec<Token>, grammar: &Grammar) -> Option<Tree> {
 
-        fn append<'a, 'b>(i: usize, item: Item<'a>, chart: &'b mut Vec<Vec<Item<'a>>>) {
-            for j in 0..chart[i].len() {
-                if chart[i][j] == item {
-                    return;
+        let mut nss: HashSet<String> = HashSet::new();
+
+        loop {
+            let old_size = nss.len();
+            update_nss(&mut nss, grammar);
+            if old_size == nss.len() {
+                break;
+            }
+        }
+
+        fn update_nss(nss: &mut HashSet<String>, grammar: &Grammar){
+            for rule in &grammar.productions {
+                if rule.rhs.iter().all(|symbol| nss.contains(symbol)) && !nss.contains(&rule.lhs) {
+                    nss.insert(rule.lhs.clone());
+                    println!("ADDING NULLABLE: {}", rule.lhs.clone());
                 }
             }
-            chart[i].push(item);
         }
 
         let mut chart: Vec<Vec<Item>> = vec![vec![]];
@@ -27,103 +38,109 @@ impl Parser for EarleyParser {
                     start: 0,
                     next: 0,
                     token: None,
-                    completing: None,
-                    previous: None,
                 };
                 chart[0].push(item);
             });
 
         let mut i = 0;
         while i < chart.len() {
-
-            let mut changed = true;
-
-            while changed {
-                changed = false;
-
-                let mut j = 0;
-                while j < chart[i].len() {
-                    let item = chart[i][j].clone();
-                    let symbol = (&item).next_symbol();
-                    match symbol {
-                        None => {
-                            let index = item.start;
-                            changed |= complete_op(item, &chart[index].clone(), &mut chart[i]);
-                        },
-                        Some(sym) => {
-                            if grammar.terminals.contains(sym) {
-                                scan_op(i, j, sym, &scan, &mut chart);
-                            } else {
-                                predict_op(i, sym, grammar, &mut chart);
-                            }
-                        },
-                    }
-                    j += 1;
+            let mut j = 0;
+            while j < chart[i].len() {
+                let item = chart[i][j].clone();
+                let next = (&item).next_symbol();
+                match next {
+                    None => {
+                        let index = item.start;
+                        //TODO eliminate this cloning!
+                        complete_op(item, &chart[index].clone(), &mut chart[i]);
+                    },
+                    Some(symbol) => {
+                        if grammar.terminals.contains(symbol) {
+                            scan_op(item, i, symbol, &scan, &mut chart);
+                        } else {
+                            predict_op(item, i, symbol, &nss, grammar, &mut chart);
+                        }
+                    },
                 }
+                j += 1;
             }
-
             i += 1;
         }
 
-        fn predict_op<'a, 'b>(i: usize, symbol: &'a str, grammar: &'a Grammar, chart: &'b mut Vec<Vec<Item<'a>>>) {
+        fn predict_op<'a, 'b>(item: Item<'a>, i: usize, symbol: &'a str, nss: &HashSet<String>, grammar: &'a Grammar, chart: &'b mut Vec<Vec<Item<'a>>>) {
             grammar.productions.iter()
                 .filter(|prod| prod.lhs == symbol)
                 .for_each(|prod| {
-                    let item = Item{
-                        rule: prod,
-                        start: i,
-                        next: 0,
-                        token: None,
-                        completing: None,
-                        previous: None,
-                    };
-                    append(i, item, chart);
+                    append(
+                        Item{
+                            rule: prod,
+                            start: i,
+                            next: 0,
+                            token: None,
+                        },
+                        &mut chart[i]
+                    );
+
+                    if nss.contains(&prod.lhs) {
+                        append(
+                            Item{
+                                rule: item.rule,
+                                start: item.start,
+                                next: item.next + 1,
+                                token: None,
+                            },
+                            &mut chart[i]
+                        );
+                    }
                 });
         }
 
-        fn scan_op<'a, 'b>(i: usize, j: usize, symbol: &'a str, scan: &'a Vec<Token>, chart: &'b mut Vec<Vec<Item<'a>>>) {
+        fn scan_op<'a, 'b>(item: Item<'a>, i: usize, symbol: &'a str, scan: &'a Vec<Token>, chart: &'b mut Vec<Vec<Item<'a>>>) {
             if i < scan.len() && scan[i].kind == symbol.to_string() {
                 if chart.len() <= i + 1 {
                     chart.push(vec![])
                 }
-                let item = chart[i][j].clone();
-                let new_item = Item{
-                    rule: item.rule,
-                    start: item.start,
-                    next: item.next + 1,
-                    token: Some(&scan[i]),
-                    completing: None,
-                    previous: Some(Box::new(item.clone())),
-                };
-                append(i + 1, new_item, chart);
+
+                unsafe_append(
+                    Item{
+                        rule: item.rule,
+                        start: item.start,
+                        next: item.next + 1,
+                        token: Some(&scan[i]),
+                    },
+                    &mut chart[i+1]
+                );
             }
         }
 
-        fn complete_op<'a, 'b>(item: Item<'a>, src: &'b Vec<Item<'a>>, dest: &'b mut Vec<Item<'a>>) -> bool {
-            let mut changed = false;
+        fn complete_op<'a, 'b>(item: Item<'a>, src: &'b Vec<Item<'a>>, dest: &'b mut Vec<Item<'a>>) {
             src.iter()
-                .filter(|old_item| {
-                    match old_item.clone().next_symbol() {
+                .filter(|old_item| match old_item.clone().next_symbol() {
                         None => false,
                         Some(sym) => sym == item.rule.lhs,
-                    }
                 })
-                .for_each(|old_item| {
-                    let item = Item{
-                        rule: old_item.rule,
-                        start: old_item.start,
-                        next: old_item.next + 1,
-                        token: None,
-                        completing: Some(Box::new(item.clone())),
-                        previous: Some(Box::new(old_item.clone())),
-                    };
-                    if dest.contains(&item) {
-                        return;
-                    }
-                    dest.push(item);
-                    changed = true;
-                });
-            changed
+                .for_each(|old_item| append(
+                        Item{
+                            rule: old_item.rule,
+                            start: old_item.start,
+                            next: old_item.next + 1,
+                            token: None,
+                        },
+                        dest
+                ));
+        }
+
+        fn append<'a, 'b>(item: Item<'a>, item_set: &'b mut Vec<Item<'a>>) {
+            for j in 0..item_set.len() {
+                if item_set[j] == item {
+                    return;
+                }
+            }
+            unsafe_append(item, item_set);
+        }
+
+        fn unsafe_append<'a, 'b>(item: Item<'a>, item_set: &'b mut Vec<Item<'a>>){
+            item_set.push(item);
         }
 
 //        println!("-----------------------------------------------------");
@@ -137,6 +154,7 @@ impl Parser for EarleyParser {
 //        println!("-----------------------------------------------------");
 
         fn partial_parse<'a, 'b>(i: usize, grammar: &'a Grammar, chart: &'b mut Vec<Vec<Item<'a>>>) -> (bool, Vec<Item<'a>>) {
+            //TODO switch to a usize and remove valid
             let mut complete_parses = vec![];
             let mut res = false;
             for j in 0..chart[i].len() {
@@ -151,53 +169,159 @@ impl Parser for EarleyParser {
 
         let (valid, complete_parses) = partial_parse(chart.len() - 1, grammar, &mut chart);
 
+        //TODO this message is not always correct, depricate or fix
         if complete_parses.len() != 1 {
             println!("WARN: Found {} complete parse(s)", complete_parses.len());
         }
 
+        return if valid {
+            Some(parse_tree(grammar, &scan, chart))
+        } else {
+            None
+        };
 
-        if !valid {
-            return None;
-        }
+        //TODO refactor to reduce long and duplicated parameter lists
+        fn parse_tree<'a>(grammar: &'a Grammar, scan: &'a Vec<Token>, chart: Vec<Vec<Item<'a>>>) -> Tree {
 
-        let first_parse : Tree = build_nodes(&complete_parses.first().unwrap());
-        return Some(first_parse);
-
-        fn build_nodes(root: &Item) -> Tree {
-            let down = match root.completing.clone() {
-                Some(node) => {
-                    build_nodes(&unbox(node))
-                },
-                None => {
-                    match root.token { //Leaf Node Creation
-                        Some(t) => Tree{ //Non-empty rhs
-                            lhs: t.clone(),
-                            children: vec![],
+            fn aux<'a>(start: Node, edge: &Edge, grammar: &'a Grammar, scan: &'a Vec<Token>, chart: &Vec<Vec<Edge>>) -> Tree {
+                match edge.rule{ //TODO need to figure out what happens for NULL
+                    None => Tree{ //Non-empty rhs
+                        lhs: scan[start].clone(),
+                        children: vec![],
+                    },
+                    Some(rule) => Tree{
+                        lhs: Token{
+                            kind: rule.lhs.clone(),
+                            lexeme: String::new(),
                         },
-                        None => Tree::null(), //Empty rhs
+                        children: {
+                            let children: Vec<Tree> = top_list(start, edge, grammar, scan, chart).iter().rev()
+                                .map(|&(node, ref edge)| aux(node, &edge, grammar, scan, chart))
+                                .collect();
+                            if children.is_empty() {
+                                vec![Tree::null()]
+                            } else {
+                                children
+                            }
+                        },
                     }
-
-                }
-            };
-
-            let prev = root.previous.clone();
-            let mut left = vec![];
-            if prev.is_some() {
-                let p: Item = unbox(prev.unwrap());
-                if p.next > 0 {
-                    left.extend(build_nodes(&p).children);
                 }
             }
 
-            left.push(down);
+            let start: Node = 0;
+            let finish: Node = chart.len() - 1;
 
-            return Tree{ //Inner Node Creation
-                lhs: Token{
-                    kind: root.rule.lhs.to_string(),
-                    lexeme: "".to_string(),
-                },
-                children: left,
+            //TODO build the parse chart during the main loop
+            let mut parse_chart: Vec<Vec<Edge>> = Vec::with_capacity(chart.len());
+            for _ in 0..chart.len() {
+                parse_chart.push(vec![]);
+            }
+            for i in 0..chart.len()  {
+                for item in &chart[i] {
+                    if item.is_complete() {
+                        parse_chart[item.start].push(Edge{
+                            rule: Some(item.rule),
+                            finish: i
+                        })
+                    }
+                }
+            }
+
+//            println!("-----------------------------------------------------");
+//            for i in 0..parse_chart.len() {
+//                println!("SET {}", i);
+//                for j in 0..parse_chart[i].len() {
+//                    println!("{}", parse_chart[i][j].to_string());
+//                }
+//                println!();
+//            }
+//            println!("-----------------------------------------------------");
+
+            let first_edge = parse_chart[start].iter()
+                .find(|edge| edge.finish == finish && edge.rule.unwrap().lhs == grammar.start);
+            match first_edge {
+                None => panic!("Failed to find start item to begin parse"),
+                Some(edge) => aux(start, edge, grammar, scan, &parse_chart)
+            }
+        }
+
+        fn top_list<'a>(start: Node, edge: &Edge, grammar: &'a Grammar, scan: &'a Vec<Token>, chart: &Vec<Vec<Edge<'a>>>) -> Vec<(Node, Edge<'a>)> {
+            let symbols: &Vec<String> = &edge.rule.unwrap().rhs;
+            let bottom: usize = symbols.len();
+            let leaf = |depth: usize, node: Node| depth == bottom && node == edge.finish;
+            let child = |edge: &Edge| edge.finish;
+            let edges = |depth: usize, node: Node| -> Vec<Edge> {
+                if depth >= bottom {
+                    vec![]
+                } else {
+                    let symbol = &symbols[depth];
+                    if grammar.terminals.contains(symbol) {
+//                        println!("HIT TERMINAL scan={} symbol={}", scan[node].kind, symbol);
+
+                        if scan[node].kind == *symbol {
+                            vec![Edge{
+                                rule: None,
+                                finish: node + 1
+                            }]
+                        } else {
+                            vec![]
+                        }
+                    } else { //TODO return iterators instead to avoid collection and cloning
+                        chart[node].iter()
+                            .filter(|edge| edge.rule.unwrap().lhs == *symbol)
+                            .cloned()
+                            .collect()
+                    }
+                }
             };
+            match df_search(&edges, &child, &leaf, start) {
+                None => panic!("Failed to decompose parse edge of recognized scan"),
+                Some(path) => path
+            }
+        }
+
+        fn df_search<'a>(edges: &Fn(usize, Node) -> Vec<Edge<'a>>,
+                     child: &Fn(&Edge) -> Node,
+                     leaf: &Fn(usize, Node) -> bool,
+                     root: Node)
+            -> Option<Vec<(Node, Edge<'a>)>> {
+
+//            println!("-----------------------------------------------------");
+//            println!("STARTING DF_SEARCH AT {}", root);
+//            println!("-----------------------------------------------------");
+
+            fn aux<'a>(edges: &Fn(usize, Node) -> Vec<Edge<'a>>,
+                       child: &Fn(&Edge) -> Node,
+                       leaf: &Fn(usize, Node) -> bool,
+                       depth: usize,
+                       root: Node)
+                -> Option<Vec<(Node, Edge<'a>)>> {
+
+//                println!("aux at depth={} root={}", depth, root);
+
+                if leaf(depth, root) {
+//                    println!("LEAF");
+
+                    Some(vec![])
+                } else {
+//                    println!("NON-LEAF");
+
+                    for edge in edges(depth, root) {
+                        let mut res = aux(edges, child, leaf, depth + 1, child(&edge));
+
+                        match res {
+                            None => {},
+                            Some(mut path) => {
+                                path.push((root, edge));
+                                return Some(path);
+                            }
+                        }
+                    }
+                    None
+                }
+            }
+
+            aux(edges, child, leaf, 0, root)
         }
     }
 }
@@ -208,16 +332,19 @@ struct Item<'a> {
     start: usize,
     next: usize,
     token: Option<&'a Token>,
-    completing: Option<Box<Item<'a>>>,
-    previous: Option<Box<Item<'a>>>,
 }
 
 impl<'a> Item<'a> {
     fn next_symbol<'b>(&'b self) -> Option<&'a str> {
         if self.next < self.rule.rhs.len() {
-            return Some(&self.rule.rhs[self.next][..]);
+            Some(&self.rule.rhs[self.next][..])
+        } else {
+            None
         }
-        return None;
+    }
+
+    fn is_complete(&self) -> bool {
+        self.next >= self.rule.rhs.len()
     }
 
     #[allow(dead_code)]
@@ -233,10 +360,31 @@ impl<'a> Item<'a> {
         if self.next == self.rule.rhs.len() {
             rule_string.push_str(". ");
         }
-        return format!("{}: {} p:{} c:{}", rule_string, self.start, if self.previous.is_some() {"SOME"} else {"NONE"}, if self.completing.is_some() {"SOME"} else {"NONE"});
+        format!("{} ({})", rule_string, self.start)
     }
 }
 
-fn unbox<T>(value: Box<T>) -> T {
-    *value
+#[derive(Clone)]
+struct Edge<'a> {
+    rule: Option<&'a Production>,
+    finish: usize,
 }
+
+impl<'a> Edge<'a> {
+    #[allow(dead_code)]
+    fn to_string(&'a self) -> String {
+        match self.rule {
+            None => format!("NONE ({})", self.finish),
+            Some(rule) => {
+                let mut rule_string = format!("{} -> ", rule.lhs);
+                for i in 0..rule.rhs.len() {
+                    rule_string.push_str(rule.rhs.get(i).unwrap());
+                    rule_string.push(' ');
+                }
+                format!("{} ({})", rule_string, self.finish)
+            }
+        }
+    }
+}
+
+type Node = usize;

--- a/src/core/parse/earley.rs
+++ b/src/core/parse/earley.rs
@@ -18,7 +18,6 @@ impl Parser for EarleyParser {
                     rule: prod,
                     start: 0,
                     next: 0,
-                    token: None,
                 };
                 chart[0].push(item);
             });
@@ -62,7 +61,6 @@ impl Parser for EarleyParser {
                             rule: prod,
                             start: i,
                             next: 0,
-                            token: None,
                         },
                         &mut chart[i]
                     );
@@ -73,7 +71,6 @@ impl Parser for EarleyParser {
                                 rule: item.rule,
                                 start: item.start,
                                 next: item.next + 1,
-                                token: None,
                             },
                             &mut chart[i]
                         );
@@ -92,7 +89,6 @@ impl Parser for EarleyParser {
                         rule: item.rule,
                         start: item.start,
                         next: item.next + 1,
-                        token: Some(&scan[i]),
                     },
                     &mut chart[i+1]
                 );
@@ -111,7 +107,6 @@ impl Parser for EarleyParser {
                     rule: old_item.rule,
                     start: old_item.start,
                     next: old_item.next + 1,
-                    token: None,
                 }));
 
             for item in advanced {
@@ -243,7 +238,6 @@ struct Item<'a> {
     rule: &'a Production,
     start: usize,
     next: usize,
-    token: Option<&'a Token>,
 }
 
 impl<'a> Item<'a> {

--- a/src/core/parse/earley.rs
+++ b/src/core/parse/earley.rs
@@ -171,7 +171,7 @@ impl Parser for EarleyParser {
         fn parse_tree<'a>(grammar: &'a Grammar, scan: &'a Vec<Token>, chart: Vec<Vec<Item<'a>>>) -> Tree {
 
             fn aux<'a>(start: Node, edge: &Edge, grammar: &'a Grammar, scan: &'a Vec<Token>, chart: &Vec<Vec<Edge>>) -> Tree {
-                match edge.rule{ //TODO need to figure out what happens for NULL
+                match edge.rule{
                     None => Tree{ //Non-empty rhs
                         lhs: scan[start].clone(),
                         children: vec![],
@@ -182,14 +182,13 @@ impl Parser for EarleyParser {
                             lexeme: String::new(),
                         },
                         children: {
-                            let children: Vec<Tree> = top_list(start, edge, grammar, scan, chart).iter().rev()
+                            let mut children: Vec<Tree> = top_list(start, edge, grammar, scan, chart).iter().rev()
                                 .map(|&(node, ref edge)| aux(node, &edge, grammar, scan, chart))
                                 .collect();
-                            if children.is_empty() {
-                                vec![Tree::null()]
-                            } else {
-                                children
+                            if children.is_empty() { //empty rhs
+                                children.push(Tree::null());
                             }
+                            children
                         },
                     }
                 }

--- a/src/core/parse/earley.rs
+++ b/src/core/parse/earley.rs
@@ -10,23 +10,28 @@ pub struct EarleyParser;
 impl Parser for EarleyParser {
     fn parse(&self, scan: Vec<Token>, grammar: &Grammar) -> Option<Tree> {
 
-        let mut nss: HashSet<String> = HashSet::new();
-
-        loop {
-            let old_size = nss.len();
-            update_nss(&mut nss, grammar);
-            if old_size == nss.len() {
-                break;
-            }
-        }
-
-        fn update_nss(nss: &mut HashSet<String>, grammar: &Grammar){
-            for rule in &grammar.productions {
-                if rule.rhs.iter().all(|symbol| nss.contains(symbol)) && !nss.contains(&rule.lhs) {
-                    nss.insert(rule.lhs.clone());
+        //TODO improve using quadratic time algorithm https://github.com/jeffreykegler/kollos/blob/master/notes/misc/loup2.md
+        fn build_nss(grammar: &Grammar) ->  HashSet<String> {
+            fn update_nss(nss: &mut HashSet<String>, grammar: &Grammar){
+                for rule in &grammar.productions {
+                    if rule.rhs.iter().all(|symbol| nss.contains(symbol)) && !nss.contains(&rule.lhs) {
+                        nss.insert(rule.lhs.clone());
+                    }
                 }
             }
+
+            let mut nss: HashSet<String> = HashSet::new();
+            loop {
+                let old_size = nss.len();
+                update_nss(&mut nss, grammar);
+                if old_size == nss.len() {
+                    break;
+                }
+            }
+            nss
         }
+
+        let nss: HashSet<String> = build_nss(grammar);
 
         let mut chart: Vec<Vec<Item>> = vec![vec![]];
         grammar.productions.iter()

--- a/src/core/parse/mod.rs
+++ b/src/core/parse/mod.rs
@@ -237,8 +237,8 @@ mod tests {
         //setup
         let productions = build_prods(&[
             "S expr",
-            "expr ( expr )",
-            "expr expr OP expr",
+            "S S OP expr",
+            "expr ( S )",
             "expr ID",
         ]);
         let grammar = Grammar::from(productions);
@@ -257,26 +257,28 @@ mod tests {
         //verify
         assert_eq!(tree.unwrap().to_string(),
 "└── S
+    ├── S
+    │   ├── S
+    │   │   └── expr
+    │   │       ├── ( <- 'xy'
+    │   │       ├── S
+    │   │       │   ├── S
+    │   │       │   │   └── expr
+    │   │       │   │       └── ID <- 'xy'
+    │   │       │   ├── OP <- 'xy'
+    │   │       │   └── expr
+    │   │       │       └── ID <- 'xy'
+    │   │       └── ) <- 'xy'
+    │   ├── OP <- 'xy'
+    │   └── expr
+    │       └── ID <- 'xy'
+    ├── OP <- 'xy'
     └── expr
-        ├── expr
-        │   ├── expr
-        │   │   ├── ( <- 'xy'
-        │   │   ├── expr
-        │   │   │   ├── expr
-        │   │   │   │   └── ID <- 'xy'
-        │   │   │   ├── OP <- 'xy'
-        │   │   │   └── expr
-        │   │   │       └── ID <- 'xy'
-        │   │   └── ) <- 'xy'
-        │   ├── OP <- 'xy'
+        ├── ( <- 'xy'
+        ├── S
         │   └── expr
         │       └── ID <- 'xy'
-        ├── OP <- 'xy'
-        └── expr
-            ├── ( <- 'xy'
-            ├── expr
-            │   └── ID <- 'xy'
-            └── ) <- 'xy'"
+        └── ) <- 'xy'"
         );
     }
 
@@ -437,6 +439,70 @@ mod tests {
     │   └──  <- 'NULL'
     └── w
         └── WHITESPACE <- 'xy'"
+        );
+    }
+
+    #[test]
+    fn advanced_parse_build(){
+        //setup
+        let productions = build_prods(&[
+            "sum sum PM prod",
+            "sum prod",
+            "prod prod MD fac",
+            "prod fac",
+            "fac LPAREN sum RPAREN",
+            "fac num",
+            "num DIGIT num",
+            "num DIGIT"
+        ]);
+        let grammar = Grammar::from(productions);
+
+        let scan = vec![
+            Token{ kind: "DIGIT".to_string(), lexeme: "1".to_string() },
+            Token{ kind: "PM".to_string(), lexeme: "+".to_string() },
+            Token{ kind: "LPAREN".to_string(), lexeme: "(".to_string() },
+            Token{ kind: "DIGIT".to_string(), lexeme: "2".to_string() },
+            Token{ kind: "MD".to_string(), lexeme: "*".to_string() },
+            Token{ kind: "DIGIT".to_string(), lexeme: "3".to_string() },
+            Token{ kind: "PM".to_string(), lexeme: "-".to_string() },
+            Token{ kind: "DIGIT".to_string(), lexeme: "4".to_string() },
+            Token{ kind: "RPAREN".to_string(), lexeme: ")".to_string() },
+        ];
+
+        let parser = def_parser();
+
+        //execute
+        let tree = parser.parse(scan, &grammar);
+
+        //verify
+        assert_eq!(tree.unwrap().to_string(),
+"└── sum
+    ├── sum
+    │   └── prod
+    │       └── fac
+    │           └── num
+    │               └── DIGIT <- '1'
+    ├── PM <- '+'
+    └── prod
+        └── fac
+            ├── LPAREN <- '('
+            ├── sum
+            │   ├── sum
+            │   │   └── prod
+            │   │       ├── prod
+            │   │       │   └── fac
+            │   │       │       └── num
+            │   │       │           └── DIGIT <- '2'
+            │   │       ├── MD <- '*'
+            │   │       └── fac
+            │   │           └── num
+            │   │               └── DIGIT <- '3'
+            │   ├── PM <- '-'
+            │   └── prod
+            │       └── fac
+            │           └── num
+            │               └── DIGIT <- '4'
+            └── RPAREN <- ')'"
         );
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,7 +1,6 @@
 extern crate padd;
 
 use padd::FormatJobRunner;
-use std::io;
 use std::io::Read;
 use std::io::Write;
 use std::fs::File;
@@ -134,7 +133,7 @@ fn load_spec(name: &str) -> String {
     let spec_file = File::open(format!("tests/spec/{}", name));
     match spec_file {
         Ok(_) => {
-            spec_file.unwrap().read_to_string(&mut spec);
+            spec_file.unwrap().read_to_string(&mut spec).unwrap();
         },
         Err(e) => panic!("Could't find specification file: {}", e),
     }
@@ -146,7 +145,7 @@ fn load_input(name: &str) -> String {
     let input_file = File::open(format!("tests/input/{}", name));
     match input_file {
         Ok(_) => {
-            input_file.unwrap().read_to_string(&mut input);
+            input_file.unwrap().read_to_string(&mut input).unwrap();
         },
         Err(e) => panic!("Could't find input file: {}", e),
     }
@@ -159,13 +158,13 @@ fn assert_matches_file(result: String, file_name: &str){
     let output_file = File::open(&file_path);
     match output_file {
         Ok(_) => {
-            output_file.unwrap().read_to_string(&mut output);
+            output_file.unwrap().read_to_string(&mut output).unwrap();
         },
         Err(_) => {
             let mut output_file = File::create(&file_path);
             match output_file {
                 Ok(_) => {
-                    output_file.unwrap().write(result.as_bytes());
+                    output_file.unwrap().write(result.as_bytes()).unwrap();
                 },
                 Err(e) => panic!("Couldn't create output file: {}", e),
             }


### PR DESCRIPTION
Re-Implemented the Earley parser to fix issues seen with epsilon productions in #11.
The resulting parser is different in three ways:
 - epsilon productions are predicted using the nullable symbols of a grammar, rather than using and extra completion loop.
 - the parse tree is produced by recursing through a modified earley item chart (parse_chart) using a depth-first search to find only the first parse tree. This algorithm replaces an algorithm which recursively built the entire parse forest using "back pointers" established during the recognition phase.
 - the warning for ambiguous parses was removed after it was discovered that grammar and scan producing two parse trees did not trigger the warning (false negative).

As a result of these modifications, the performance of the parser has drastically improved, and memory usage during parse-tree construction has been reduced (since we only build a single parse tree rather than the whole forest).