### PR TITLE
Better Error Handling

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,6 +3,7 @@ extern crate stopwatch;
 
 use self::regex::Regex;
 use self::stopwatch::Stopwatch;
+use padd;
 use padd::FormatJobRunner;
 use std::env;
 use std::io;
@@ -122,7 +123,7 @@ fn dir_recur(dir_path: &Path, fn_regex: &Regex, fjr: &FormatJobRunner){
         });
 }
 
-fn load_spec(spec_path: &String) -> Result<FormatJobRunner, String> {
+fn load_spec(spec_path: &String) -> Result<FormatJobRunner, padd::BuildError> {
     let mut spec = String::new();
 
     let spec_file = File::open(spec_path);

--- a/src/core/fmt/mod.rs
+++ b/src/core/fmt/mod.rs
@@ -1,6 +1,5 @@
 use core::parse::Tree;
 use core::fmt::pattern::*;
-use core::Error;
 use std::collections::HashMap;
 
 mod pattern;
@@ -10,15 +9,13 @@ pub struct Formatter {
 }
 
 impl Formatter {
-    pub fn create(patterns: Vec<PatternPair>) -> Result<Formatter, Error> {
+    pub fn create(patterns: Vec<PatternPair>) -> Result<Formatter, BuildError> {
         let mut pattern_map = HashMap::new();
         for pattern_pair in patterns {
-            match generate_pattern(&pattern_pair.pattern[..]) {
-                Ok(pattern) => {
-                    pattern_map.insert(pattern_pair.production, pattern);
-                },
-                Err(e) => return Err(e),
-            }
+            pattern_map.insert(
+                pattern_pair.production,
+                generate_pattern(&pattern_pair.pattern[..])?
+            );
         }
         Ok(Formatter{
             pattern_map,
@@ -33,6 +30,8 @@ impl Formatter {
         format_job.run()
     }
 }
+
+pub type BuildError = pattern::BuildError;
 
 struct FormatJob<'a> {
     parse: &'a Tree,
@@ -95,11 +94,13 @@ impl<'a> FormatJob<'a> {
             }
             match children.get(capture.child_index) {
                 Some(child) => return self.recur(child, &inner_scope),
+                //TODO use actual error here rather than panic!
                 None => panic!("Pattern index out of bounds: index={} children={}", capture.child_index, children.len()),
             }
         } else {
             match children.get(capture.child_index) {
                 Some(child) => return self.recur(child, outer_scope),
+                //TODO use actual error here rather than panic!
                 None => panic!("Pattern index out of bounds: index={} children={}", capture.child_index, children.len()),
             }
         }

--- a/src/core/fmt/mod.rs
+++ b/src/core/fmt/mod.rs
@@ -1,4 +1,5 @@
 use core::parse::Tree;
+use core::parse::Production;
 use core::fmt::pattern::*;
 use std::collections::HashMap;
 
@@ -13,8 +14,8 @@ impl Formatter {
         let mut pattern_map = HashMap::new();
         for pattern_pair in patterns {
             pattern_map.insert(
-                pattern_pair.production,
-                generate_pattern(&pattern_pair.pattern[..])?
+                pattern_pair.production.to_string(),
+                generate_pattern(&pattern_pair.pattern[..], &pattern_pair.production)?
             );
         }
         Ok(Formatter{
@@ -94,13 +95,11 @@ impl<'a> FormatJob<'a> {
             }
             match children.get(capture.child_index) {
                 Some(child) => return self.recur(child, &inner_scope),
-                //TODO use actual error here rather than panic!
                 None => panic!("Pattern index out of bounds: index={} children={}", capture.child_index, children.len()),
             }
         } else {
             match children.get(capture.child_index) {
                 Some(child) => return self.recur(child, outer_scope),
-                //TODO use actual error here rather than panic!
                 None => panic!("Pattern index out of bounds: index={} children={}", capture.child_index, children.len()),
             }
         }
@@ -108,6 +107,6 @@ impl<'a> FormatJob<'a> {
 }
 
 pub struct PatternPair {
-    pub production: String,
+    pub production: Production,
     pub pattern: String,
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,29 +1,4 @@
-//use core::scan::ScanningError;
-//use core::parse::ParsingError;
-//use std::fmt as stdfmt;
-
 pub mod fmt;
 pub mod parse;
 pub mod scan;
 pub mod spec;
-//
-//#[derive(Debug)]
-//pub enum Error{
-//    ScanErr(ScanningError),
-//    ParseErr(ParsingError),
-//    Err(String),
-//}
-//
-//impl Error{
-//    #[allow(dead_code)]
-//    fn fmt(&self, f: &mut stdfmt::Formatter) -> stdfmt::Result {
-//        write!(f, "{}", self.to_string())
-//    }
-//    pub fn to_string(&self) -> String {
-//        match self {
-//            &Error::ScanErr(ref se) => format!("Failed to scan input: No accepting scans after ({},{}): {}...", se.line, se.character, se.sequence),
-//            &Error::ParseErr(ref pe) => format!("Failed to parse input: {}", pe.message),
-//            &Error::Err(ref msg) => format!("{}", msg),
-//        }
-//    }
-//}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,28 +1,29 @@
-use core::scan::ScanningError;
-use std::fmt as stdfmt;
+//use core::scan::ScanningError;
+//use core::parse::ParsingError;
+//use std::fmt as stdfmt;
 
 pub mod fmt;
 pub mod parse;
 pub mod scan;
 pub mod spec;
-
-#[derive(Debug)]
-pub enum Error{
-    ScanErr(ScanningError),
-    ParseErr(),
-    Err(String),
-}
-
-impl Error{
-    #[allow(dead_code)]
-    fn fmt(&self, f: &mut stdfmt::Formatter) -> stdfmt::Result {
-        write!(f, "{}", self.to_string())
-    }
-    pub fn to_string(&self) -> String {
-        match self {
-            &Error::ScanErr(ref se) => format!("Failed to scan input: No accepting scans after ({},{}): {}...", se.line, se.character, se.sequence),
-            &Error::ParseErr() => format!("Failed to parse input"),
-            &Error::Err(ref msg) => format!("{}", msg),
-        }
-    }
-}
+//
+//#[derive(Debug)]
+//pub enum Error{
+//    ScanErr(ScanningError),
+//    ParseErr(ParsingError),
+//    Err(String),
+//}
+//
+//impl Error{
+//    #[allow(dead_code)]
+//    fn fmt(&self, f: &mut stdfmt::Formatter) -> stdfmt::Result {
+//        write!(f, "{}", self.to_string())
+//    }
+//    pub fn to_string(&self) -> String {
+//        match self {
+//            &Error::ScanErr(ref se) => format!("Failed to scan input: No accepting scans after ({},{}): {}...", se.line, se.character, se.sequence),
+//            &Error::ParseErr(ref pe) => format!("Failed to parse input: {}", pe.message),
+//            &Error::Err(ref msg) => format!("{}", msg),
+//        }
+//    }
+//}

--- a/src/core/parse/earley.rs
+++ b/src/core/parse/earley.rs
@@ -115,7 +115,7 @@ impl Parser for EarleyParser {
             }
         }
 
-        fn append<'a, 'b>(item: Item<'a>, item_set: &'b mut Vec<Item<'a>>) {
+        fn append<'a, 'b>(item: Item<'a>, item_set: &'b mut Vec<Item<'a>>){
             for j in 0..item_set.len() {
                 if item_set[j] == item {
                     return;
@@ -130,14 +130,30 @@ impl Parser for EarleyParser {
 
         fn recognized<'a, 'b>(grammar: &'a Grammar, chart: &'b Vec<Vec<Item<'a>>>) -> bool {
             chart.last().unwrap().iter()
-                .any(|item| item.rule.lhs == grammar.start && item.next >= item.rule.rhs.len() && item.start == 0)
+                .any(|item| item.rule.lhs == grammar.start
+                    && item.next >= item.rule.rhs.len()
+                    && item.start == 0)
         }
 
         return if recognized(grammar, &chart) {
-            Ok(parse_tree(grammar, &scan, parse_chart))
+            if i - 1 == scan.len() {
+                Ok(parse_tree(grammar, &scan, parse_chart))
+            } else {
+                Err(parse::Error{
+                    message: format!(
+                        "Largest parse did not consume all tokens: {} of {}",
+                        i - 1,
+                        scan.len()
+                    ),
+                })
+            }
         } else {
             Err(parse::Error{
-                message: format!("Recognition failed after token {}: kind='{}' lexeme='{}'", i, scan[i - 1].kind, scan[i - 1].lexeme),
+                message: format!(
+                    "Recognition failed at token {}: {}",
+                    i,
+                    scan[i - 1].to_string()
+                ),
             })
         };
 

--- a/src/core/parse/earley.rs
+++ b/src/core/parse/earley.rs
@@ -2,12 +2,13 @@ use core::parse::Parser;
 use core::parse::Grammar;
 use core::parse::Production;
 use core::parse::Tree;
+use core::parse;
 use core::scan::Token;
 
 pub struct EarleyParser;
 
 impl Parser for EarleyParser {
-    fn parse(&self, scan: Vec<Token>, grammar: &Grammar) -> Option<Tree> {
+    fn parse(&self, scan: Vec<Token>, grammar: &Grammar) -> Result<Tree, parse::Error> {
         let mut parse_chart: Vec<Vec<Edge>> = vec![];
         let mut chart: Vec<Vec<Item>> = vec![vec![]];
 
@@ -133,9 +134,11 @@ impl Parser for EarleyParser {
         }
 
         return if recognized(grammar, &chart) {
-            Some(parse_tree(grammar, &scan, parse_chart))
+            Ok(parse_tree(grammar, &scan, parse_chart))
         } else {
-            None
+            Err(parse::Error{
+                message: format!("Recognition failed after token {}: kind='{}' lexeme='{}'", i, scan[i - 1].kind, scan[i - 1].lexeme),
+            })
         };
 
         //TODO refactor to reduce long and duplicated parameter lists

--- a/src/core/parse/mod.rs
+++ b/src/core/parse/mod.rs
@@ -1,11 +1,13 @@
 use std::collections::HashSet;
 use std::collections::HashMap;
+use std::error;
+use std::fmt;
 use core::scan::Token;
 
 mod earley;
 
 pub trait Parser {
-    fn parse(&self, scan: Vec<Token>, grammar: &Grammar) -> Option<Tree>;
+    fn parse(&self, scan: Vec<Token>, grammar: &Grammar) -> Result<Tree, Error>;
 }
 
 pub fn def_parser() -> Box<Parser> {
@@ -71,6 +73,23 @@ impl Tree {
     pub fn production(&self) -> String {
         let vec: Vec<String> = self.children.iter().map(|s| s.lhs.kind.clone()).collect();
         return format!("{} {}", self.lhs.kind, (&vec[..]).join(" "));
+    }
+}
+
+#[derive(Debug)]
+pub struct Error {
+    pub message: String,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl error::Error for Error {
+    fn cause(&self) -> Option<&error::Error> {
+        None
     }
 }
 

--- a/src/core/parse/mod.rs
+++ b/src/core/parse/mod.rs
@@ -572,4 +572,25 @@ mod tests {
             └── RPAREN <- ')'"
         );
     }
+
+    #[test]
+    fn parse_must_consume() {
+        //setup
+        let productions = build_prods(&["s "]);
+        let grammar = Grammar::from(productions);
+
+        let scan = vec![Token{
+            kind: "kind".to_string(),
+            lexeme: "lexeme".to_string(),
+        }];
+
+        let parser = def_parser();
+
+        //execute
+        let res = parser.parse(scan, &grammar);
+
+        //verify
+        assert!(res.is_err());
+        assert_eq!(format!("{}", res.err().unwrap()), "Largest parse did not consume all tokens: 0 of 1")
+    }
 }

--- a/src/core/scan/maximal_munch.rs
+++ b/src/core/scan/maximal_munch.rs
@@ -1,15 +1,15 @@
+use core::scan;
 use core::scan::DFA;
 use core::scan::Token;
 use core::scan::State;
 use core::scan::Scanner;
-use core::scan::ScanningError;
 use core::scan::FAIL_SEQUENCE_LENGTH;
 use std::cmp;
 
 pub struct MaximalMunchScanner;
 
 impl Scanner for MaximalMunchScanner {
-    fn scan<'a, 'b>(&self, input: &'a str, dfa: &'b DFA) -> Result<Vec<Token>, ScanningError> {
+    fn scan<'a, 'b>(&self, input: &'a str, dfa: &'b DFA) -> Result<Vec<Token>, scan::Error> {
 
         fn scan_one<'a, 'b>(input: &'a [char], line: usize, character: usize, dfa: &'b DFA) -> (usize, &'b State, usize, usize)
         {
@@ -68,7 +68,7 @@ impl Scanner for MaximalMunchScanner {
             if scanned == 0 {
                 let seq_len = cmp::min(input.len(), FAIL_SEQUENCE_LENGTH);
 
-                return Err(ScanningError{
+                return Err(scan::Error{
                     sequence: input.iter().take(seq_len).collect(),
                     line,
                     character,

--- a/src/core/scan/mod.rs
+++ b/src/core/scan/mod.rs
@@ -1,9 +1,11 @@
 use std::collections::HashMap;
+use std::error;
+use std::fmt;
 
 pub mod maximal_munch;
 
 pub trait Scanner {
-    fn scan<'a, 'b>(&self, input: &'a str, dfa: &'b DFA) -> Result<Vec<Token>, ScanningError>;
+    fn scan<'a, 'b>(&self, input: &'a str, dfa: &'b DFA) -> Result<Vec<Token>, Error>;
 }
 
 pub fn def_scanner() -> Box<Scanner> {
@@ -19,8 +21,28 @@ pub struct Token {
 }
 
 impl Token {
+    //TODO fix this method or remove it
     pub fn to_string(&self) -> String {
         format!("{} <- '{}'", self.kind, self.lexeme.replace('\n', "\\n").replace('\t', "\\t"))
+    }
+}
+
+#[derive(Debug)]
+pub struct Error {
+    sequence: String,
+    character: usize,
+    line: usize,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "No accepting scans after ({},{}): {}...", self.line, self.character, self.sequence)
+    }
+}
+
+impl error::Error for Error {
+    fn cause(&self) -> Option<&error::Error> {
+        None
     }
 }
 
@@ -129,13 +151,6 @@ impl TransitionDelta for RuntimeTransitionDelta {
             None => false,
         }
     }
-}
-
-#[derive(Debug)]
-pub struct ScanningError {
-    pub sequence: String,
-    pub character: usize,
-    pub line: usize,
 }
 
 #[cfg(test)]

--- a/src/core/spec.rs
+++ b/src/core/spec.rs
@@ -1,17 +1,21 @@
+use std;
+use std::error;
 use core::parse::build_prods;
 use core::scan::def_scanner;
 use core::parse::def_parser;
+use core::fmt;
 use core::fmt::PatternPair;
 use core::fmt::Formatter;
+use core::parse;
 use core::parse::Grammar;
 use core::parse::Production;
 use core::parse::Tree;
+use core::scan;
 use core::scan::State;
 use core::scan::Kind;
 use core::scan::DFA;
 use core::scan::CompileTransitionDelta;
 use core::scan::RuntimeTransitionDelta;
-use core::Error;
 use std::collections::HashMap;
 
 static SPEC_ALPHABET: &'static str = "`-=~!@#$%^&*()_+{}|[]\\;':\"<>?,./QWERTYUIOPASDFGHJKLZXCVBNM1234567890abcdefghijklmnopqrstuvwxyz \n\t";
@@ -155,14 +159,14 @@ lazy_static! {
     static ref SPEC_GRAMMAR: Grammar = Grammar::from(SPEC_PRODUCTIONS.clone());
 }
 
-pub fn generate_spec(parse: &Tree) -> Result<(DFA, Grammar, Formatter), Error> {
+pub fn generate_spec(parse: &Tree) -> Result<(DFA, Grammar, Formatter), GenError> {
     let dfa = generate_dfa(parse.get_child(0));
     let (grammar, pattern_pairs) = generate_grammar(parse.get_child(1));
-    match Formatter::create(pattern_pairs) {
-        Ok(formatter) => Ok((dfa, grammar, formatter)),
-        Err(e) => Err(e),
-    }
+    let formatter = Formatter::create(pattern_pairs)?;
+    Ok((dfa, grammar, formatter))
 }
+
+pub type GenError = fmt::BuildError;
 
 fn generate_dfa(tree: &Tree) -> DFA {
     let mut delta: HashMap<State, HashMap<char, State>> = HashMap::new();
@@ -212,7 +216,7 @@ fn generate_dfa_states<'a>(states_node: &Tree, delta: &mut HashMap<State, HashMa
 
         generate_dfa_trans(transopt_node.get_child(0), &mut state_delta, delta, tokenizer, head_state);
         for state in &tail_states {
-            extend_delta((*state), state_delta.clone(), delta);
+            extend_delta(*state, state_delta.clone(), delta);
         }
         extend_delta(head_state, state_delta, delta);
     }
@@ -385,21 +389,48 @@ fn generate_grammar_ids<'a, 'b>(ids_node: &'a Tree, accumulator: &'b mut Vec<Str
     }
 }
 
-pub fn parse_spec(input: &str) -> Result<Tree, Error> {
-    let scanner = def_scanner();
-    let parser = def_parser();
+pub fn parse_spec(input: &str) -> Result<Tree, ParseError> {
+    SPEC_DFA.with(|f| -> Result<Tree, ParseError> {
+        let tokens = def_scanner().scan(input, f)?;
+        let parse = def_parser().parse(tokens, &SPEC_GRAMMAR)?;
+        Ok(parse)
+    })
+}
 
-    let mut res: Result<Tree, Error> = Err(Error::Err("Failed to get thread local DFA".to_string()));
-    SPEC_DFA.with(|f| {
-        res = match scanner.scan(input, f) {
-            Ok(tokens) => match parser.parse(tokens, &SPEC_GRAMMAR) {
-                Some(parse) => Ok(parse),
-                None => Err(Error::ParseErr())
-            },
-            Err(se) => Err(Error::ScanErr(se)),
+#[derive(Debug)]
+pub enum ParseError {
+    ScanErr(scan::Error),
+    ParseErr(parse::Error)
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            ParseError::ScanErr(ref err) => write!(f, "Scan error: {}", err),
+            ParseError::ParseErr(ref err) => write!(f, "Parse error: {}", err),
         }
-    });
-    res
+    }
+}
+
+impl error::Error for ParseError {
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            ParseError::ScanErr(ref err) => Some(err),
+            ParseError::ParseErr(ref err) => Some(err),
+        }
+    }
+}
+
+impl From<scan::Error> for ParseError {
+    fn from(err: scan::Error) -> ParseError {
+        ParseError::ScanErr(err)
+    }
+}
+
+impl From<parse::Error> for ParseError {
+    fn from(err: parse::Error) -> ParseError {
+        ParseError::ParseErr(err)
+    }
 }
 
 fn replace_escapes(input: &str) -> String {

--- a/src/core/spec.rs
+++ b/src/core/spec.rs
@@ -369,7 +369,7 @@ fn generate_grammar_rhss<'a, 'b>(rhss_node: &'a Tree, lhs: &'a String, accumulat
         let pattern = replace_escapes(pattern_string);
 
         pp_accumulator.push(PatternPair{
-            production: accumulator.last().unwrap().to_string(),
+            production: accumulator.last().unwrap().clone(),
             pattern,
         });
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 extern crate lazy_static;
 extern crate stopwatch;
 
+use std::error;
+use std::fmt;
 use core::scan;
 use core::scan::DFA;
 use core::scan::Scanner;
@@ -10,7 +12,6 @@ use core::parse::Grammar;
 use core::parse::Parser;
 use core::fmt::Formatter;
 use core::spec;
-use core::Error;
 
 mod core;
 
@@ -23,36 +24,94 @@ pub struct FormatJobRunner {
 }
 
 impl FormatJobRunner {
-    pub fn build(spec: &String) -> Result<FormatJobRunner, String> {
-        match spec::parse_spec(spec) {
-            Ok(parse) => {
-                match spec::generate_spec(&parse) {
-                    Ok((dfa, grammar, formatter)) => Ok(FormatJobRunner {
-                        dfa,
-                        grammar,
-                        formatter,
-                        scanner: scan::def_scanner(),
-                        parser: parse::def_parser(),
-                    }),
-                    Err(e) => Err(e.to_string())
-                }
-            },
-            Err(e) => Err(e.to_string())
-        }
+    pub fn build(spec: &String) -> Result<FormatJobRunner, BuildError> {
+        let parse = spec::parse_spec(spec)?;
+        let (dfa, grammar, formatter) = spec::generate_spec(&parse)?;
+        Ok(FormatJobRunner{
+            dfa,
+            grammar,
+            formatter,
+            scanner: scan::def_scanner(),
+            parser: parse::def_parser(),
+        })
     }
 
-    pub fn format(&self, input: &String) -> Result<String, String> {
-        let res = self.scanner.scan(input, &self.dfa);
-        match res {
-            Ok(tokens) => {
-                let tree = self.parser.parse(tokens, &self.grammar);
-                match tree {
-                    Some(parse) => Ok(self.formatter.format(&parse)),
-                    None => Err(Error::ParseErr().to_string()),
-                }
-            },
-            Err(se) => Err(Error::ScanErr(se).to_string()),
+    pub fn format(&self, input: &String) -> Result<String, FormatError> {
+        let tokens = self.scanner.scan(input, &self.dfa)?;
+        let parse = self.parser.parse(tokens, &self.grammar)?;
+        Ok(self.formatter.format(&parse))
+    }
+}
+
+#[derive(Debug)]
+pub enum BuildError {
+    SpecParseErr(spec::ParseError),
+    SpecGenErr(spec::GenError)
+}
+
+impl fmt::Display for BuildError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            BuildError::SpecParseErr(ref err) => write!(f, "Failed to parse specification: {}", err),
+            BuildError::SpecGenErr(ref err) => write!(f, "Failed to generate specification: {}", err),
         }
+    }
+}
+
+impl error::Error for BuildError {
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            BuildError::SpecParseErr(ref err) => Some(err),
+            BuildError::SpecGenErr(ref err) => Some(err),
+        }
+    }
+}
+
+impl From<spec::ParseError> for BuildError {
+    fn from(err: spec::ParseError) -> BuildError {
+        BuildError::SpecParseErr(err)
+    }
+}
+
+impl From<spec::GenError> for BuildError {
+    fn from(err: spec::GenError) -> BuildError {
+        BuildError::SpecGenErr(err)
+    }
+}
+
+#[derive(Debug)]
+pub enum FormatError {
+    ScanErr(scan::Error),
+    ParseErr(parse::Error)
+}
+
+impl fmt::Display for FormatError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            FormatError::ScanErr(ref err) => write!(f, "Failed to scan input: {}", err),
+            FormatError::ParseErr(ref err) => write!(f, "Failed to parse input: {}", err),
+        }
+    }
+}
+
+impl error::Error for FormatError {
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            FormatError::ScanErr(ref err) => Some(err),
+            FormatError::ParseErr(ref err) => Some(err),
+        }
+    }
+}
+
+impl From<scan::Error> for FormatError {
+    fn from(err: scan::Error) -> FormatError {
+        FormatError::ScanErr(err)
+    }
+}
+
+impl From<parse::Error> for FormatError {
+    fn from(err: parse::Error) -> FormatError {
+        FormatError::ParseErr(err)
     }
 }
 
@@ -78,7 +137,8 @@ s -> ACC;
 
         //verify
         assert!(res.is_err());
-        assert_eq!(res.err().unwrap(), "Failed to scan input: No accepting scans after (1,1): b...");
+        assert_eq!(format!("{}", res.err().unwrap()), "Failed to scan input: No accepting scans aft\
+        er (1,1): b...");
     }
 
     #[test]
@@ -99,7 +159,8 @@ s -> B;
 
         //verify
         assert!(res.is_err());
-        assert_eq!(res.err().unwrap(), "Failed to parse input");
+        assert_eq!(format!("{}", res.err().unwrap()), "Failed to parse input: Recognition failed af\
+        ter token 1: kind='ACC' lexeme='a'");
     }
 
     #[test]
@@ -118,7 +179,8 @@ s -> ACC;
 
         //verify
         assert!(res.is_err());
-        assert_eq!(res.err().unwrap(), "Failed to scan input: No accepting scans after (2,5): ~\n\nstart \'...");
+        assert_eq!(format!("{}", res.err().unwrap()), "Failed to parse specification: Scan error: N\
+        o accepting scans after (2,5): ~\n\nstart \'...");
     }
 
     #[test]
@@ -135,6 +197,7 @@ s -> B;
 
         //verify
         assert!(res.is_err());
-        assert_eq!(res.err().unwrap(), "Failed to parse input");
+        assert_eq!(format!("{}", res.err().unwrap()), "Failed to parse specification: Parse error: \
+        Recognition failed after token 1: kind='ID' lexeme='start'");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,8 +137,10 @@ s -> ACC;
 
         //verify
         assert!(res.is_err());
-        assert_eq!(format!("{}", res.err().unwrap()), "Failed to scan input: No accepting scans aft\
-        er (1,1): b...");
+        assert_eq!(
+            format!("{}", res.err().unwrap()),
+            "Failed to scan input: No accepting scans after (1,1): b..."
+        );
     }
 
     #[test]
@@ -159,8 +161,10 @@ s -> B;
 
         //verify
         assert!(res.is_err());
-        assert_eq!(format!("{}", res.err().unwrap()), "Failed to parse input: Recognition failed af\
-        ter token 1: kind='ACC' lexeme='a'");
+        assert_eq!(
+            format!("{}", res.err().unwrap()),
+            "Failed to parse input: Recognition failed at token 1: ACC <- 'a'"
+        );
     }
 
     #[test]
@@ -179,8 +183,10 @@ s -> ACC;
 
         //verify
         assert!(res.is_err());
-        assert_eq!(format!("{}", res.err().unwrap()), "Failed to parse specification: Scan error: N\
-        o accepting scans after (2,5): ~\n\nstart \'...");
+        assert_eq!(
+            format!("{}", res.err().unwrap()),
+            "Failed to parse specification: Scan error: No accepting scans after (2,5): ~\n\nstart \'..."
+        );
     }
 
     #[test]
@@ -197,7 +203,9 @@ s -> B;
 
         //verify
         assert!(res.is_err());
-        assert_eq!(format!("{}", res.err().unwrap()), "Failed to parse specification: Parse error: \
-        Recognition failed after token 1: kind='ID' lexeme='start'");
+        assert_eq!(
+            format!("{}", res.err().unwrap()),
+            "Failed to parse specification: Parse error: Recognition failed at token 1: ID <- 'start'"
+        );
     }
 }


### PR DESCRIPTION
Re-implemented errors using `std::error:Error` as a base, where each "module" has its own error types, rather than a single centralized error type in `core`.

Added more useful error messages for parse recognition errors. Might be sufficient for #3.

Added an error for when a parse is completed, but does not consume the entire input.

Added an error for bad child indices in pattern captures.