### PR TITLE
Fixing formatting issues of java8 spec

### DIFF
--- a/tests/input/java8_annotation
+++ b/tests/input/java8_annotation
@@ -1,0 +1,6 @@
+package com.domain.app.module;@interface AnnotationClass {
+float x();float y();
+int failures() default 0;
+String name() default "Bob";
+Double[][] matrix();
+}

--- a/tests/input/java8_interface
+++ b/tests/input/java8_interface
@@ -1,0 +1,10 @@
+package com.konjex.util.provide;
+
+/**
+ * Object that can be provided by a provider.
+ */
+public interface Providable<MatchType> extends DataClass {
+
+    MatchType getProviderKey();
+
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -300,5 +300,8 @@ fn assert_matches_file(result: String, file_name: &str) {
         }
     }
 
-    assert_eq!(output, result);
+    if output != result {
+        println!("EXPECTED:\n{}\nBUT FOUND:\n{}", output, result);
+        panic!("Output did not match file")
+    }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -63,28 +63,38 @@ fn test_lacs_complex() {
 }
 
 #[test]
-fn test_java8_simple(){
+fn test_java8_simple() {
     test_fjr("java8_simple", "java8");
 }
 
 #[test]
-fn test_java8_medium(){
+fn test_java8_medium() {
     test_fjr("java8_medium", "java8");
 }
 
 #[test]
-fn test_java8_complex_spring(){
+fn test_java8_complex_spring() {
     test_fjr("java8_complex_spring", "java8");
 }
 
 #[test]
-fn test_java8_complex_guice(){
+fn test_java8_complex_guice() {
     test_fjr("java8_complex_guice", "java8");
 }
 
 #[test]
-fn test_java8_concepts(){
+fn test_java8_concepts() {
     test_fjr("java8_concepts", "java8");
+}
+
+#[test]
+fn test_java8_annotation() {
+    test_fjr("java8_annotation", "java8");
+}
+
+#[test]
+fn test_java8_interface() {
+    test_fjr("java8_interface", "java8");
 }
 
 #[test]

--- a/tests/output/java8_annotation
+++ b/tests/output/java8_annotation
@@ -1,0 +1,13 @@
+package com.domain.app.module;
+
+@interface AnnotationClass {
+    float x();
+
+    float y();
+
+    int failures() default 0;
+
+    String name() default "Bob";
+
+    Double[][] matrix();
+}

--- a/tests/output/java8_complex_guice
+++ b/tests/output/java8_complex_guice
@@ -56,7 +56,7 @@ final class InheritingState implements State {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T> BindingImpl<T> getExplicitBinding(Key<T> key){
+    public <T> BindingImpl<T> getExplicitBinding(Key<T> key) {
         Binding<?> binding = explicitBindings.get(key);
         return binding != null ? (BindingImpl<T>)binding : parent.getExplicitBinding(key);
     }

--- a/tests/output/java8_complex_spring
+++ b/tests/output/java8_complex_spring
@@ -59,7 +59,7 @@ public final class CollectionFactory {
     }
 
     @SuppressWarnings({"unchecked", "cast", "rawtypes"})
-    public static <E> Collection<E> createApproximateCollection(@Nullable Object collection, int capacity){
+    public static <E> Collection<E> createApproximateCollection(@Nullable Object collection, int capacity) {
         if (collection instanceof LinkedList) {
             return new LinkedList<>();
         }
@@ -79,12 +79,12 @@ public final class CollectionFactory {
         }
     }
 
-    public static <E> Collection<E> createCollection(Class<?> collectionType, int capacity){
+    public static <E> Collection<E> createCollection(Class<?> collectionType, int capacity) {
         return createCollection(collectionType, null, capacity);
     }
 
     @SuppressWarnings({"unchecked", "cast"})
-    public static <E> Collection<E> createCollection(Class<?> collectionType, @Nullable Class<?> elementType, int capacity){
+    public static <E> Collection<E> createCollection(Class<?> collectionType, @Nullable Class<?> elementType, int capacity) {
         Assert.notNull(collectionType, "Collection type must not be null");
 
         if (collectionType.isInterface()) {
@@ -124,7 +124,7 @@ public final class CollectionFactory {
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public static <K, V> Map<K, V> createApproximateMap(@Nullable Object map, int capacity){
+    public static <K, V> Map<K, V> createApproximateMap(@Nullable Object map, int capacity) {
         if (map instanceof EnumMap) {
             EnumMap enumMap = new EnumMap((EnumMap)map);
             enumMap.clear();
@@ -138,12 +138,12 @@ public final class CollectionFactory {
         }
     }
 
-    public static <K, V> Map<K, V> createMap(Class<?> mapType, int capacity){
+    public static <K, V> Map<K, V> createMap(Class<?> mapType, int capacity) {
         return createMap(mapType, null, capacity);
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public static <K, V> Map<K, V> createMap(Class<?> mapType, @Nullable Class<?> keyType, int capacity){
+    public static <K, V> Map<K, V> createMap(Class<?> mapType, @Nullable Class<?> keyType, int capacity) {
         Assert.notNull(mapType, "Map type must not be null");
 
         if (mapType.isInterface()) {

--- a/tests/output/java8_concepts
+++ b/tests/output/java8_concepts
@@ -18,7 +18,7 @@ public class JavaConcepts<T extends List<int[]> , X> extends Base implements Ser
 
     Class clz4 = (int.class);
 
-    int[] arr = newint[10];
+    int[] arr = new int[10];
 
     byte bye = 0;
 
@@ -40,7 +40,7 @@ public class JavaConcepts<T extends List<int[]> , X> extends Base implements Ser
 
     int binaryLiteral = 0b101101;
 
-    List<String>[][] arrLS = (List<String>[][])newList<?>[10][];
+    List<String>[][] arrLS = (List<String>[][])new List<?>[10][];
 
     ;
     {
@@ -92,24 +92,24 @@ public class JavaConcepts<T extends List<int[]> , X> extends Base implements Ser
     }
 
     ;
-    @Deprecated() int[][][][] arr2 = newint[10][2][1][0];
+    @Deprecated() int[][][][] arr2 = new int[10][2][1][0];
 
     volatile float fff = 0x1.fffeP + 127f;
 
     char cc = 'a';
 
-    int[][] arr3 = {{1,2},{3,4}};
+    int[][] arr3 = {{1, 2}, {3, 4}};
 
     static int[] arr4[] = {};
 
     public static JavaConcepts t;
 
     static {
-        arr4 = newint[][]{{2},{1}};
+        arr4 = new int[][]{{2}, {1}};
     }
 
     {
-        arr3 = newint[][]{{2},{1}};
+        arr3 = new int[][]{{2}, {1}};
     }
 
     public enum Teste {
@@ -121,7 +121,7 @@ public class JavaConcepts<T extends List<int[]> , X> extends Base implements Ser
         m,
         @Deprecated f
         ;
-        public enum Sexo_ implements Serializable, Cloneable {
+        public enum Sexo_  implements Serializable, Cloneable{
 
         }
 
@@ -187,12 +187,10 @@ public class JavaConcepts<T extends List<int[]> , X> extends Base implements Ser
 
             public Y(int y) {
                 super();
-
             }
 
             public Y(long x) {
                 this();
-
             }
         }
 
@@ -207,12 +205,11 @@ public class JavaConcepts<T extends List<int[]> , X> extends Base implements Ser
 
         int i = (int)-1;
 
-        public QWE(String ...) {
+        public QWE(String... x) {
             <String>super(x[0]);
-
         }
 
-        public QWE(int ...) {
+        public QWE(int... x) {
             super(x[0]);
 
             i = x[0];
@@ -252,7 +249,7 @@ case 2:if (t instanceof Base) {
 
         private synchronized int doSomething()[] {
             List<? extends Number> x = new ArrayList<Integer>();
-            return newint[]{1};
+            return new int[]{1};
         }
     }
 

--- a/tests/output/java8_concepts
+++ b/tests/output/java8_concepts
@@ -275,31 +275,30 @@ public class JavaConcepts<T extends List<int[]> , X> extends Base implements Ser
             x = x == 0 ? 2 : 4;
         }
 
-        if (true) x = 1;else x = 3;
+        if (true) x = 1; else x = 3;
 
-        if (true) x = 1;else if (false) x = 3;else x = 2;
+        if (true) x = 1; else if (false) x = 3; else x = 2;
 
         while (true) {
             xxx: while (x == 3) continue xxx;
             break;
         }
 
-        do{
+        do {
             x++;
-        }while(x < 100);
-        dox++;while(x < 100);
+        } while (x < 100);
+        do x++; while (x < 100);
 
         for (@Deprecated int i : arr4[0]) {
             x--;
         }
 
-        for (@Deprecated
-        final int i = 0, j = 1; i < 10; x++) {
+        for (@Deprecated final int i = 0, j = 1; i < 10; x++) {
             break;
         }
 
         int i, j;
-        for (i = 0,j = 1; i < 10 && j < 2; i++,j--) {
+        for (i = 0, j = 1; i < 10 && j < 2; i++, j--) {
             break;
         }
     }

--- a/tests/output/java8_concepts
+++ b/tests/output/java8_concepts
@@ -48,7 +48,8 @@ public class JavaConcepts<T extends List<int[]> , X> extends Base implements Ser
         int a = (z) + y;
         a = (+z) + y;
 
-        byte b = (byte)+y;    }
+        byte b = (byte)+y;
+    }
 
     List<String> diamond1 = new LinkedList<>();
 
@@ -222,7 +223,8 @@ public class JavaConcepts<T extends List<int[]> , X> extends Base implements Ser
             }
 
             label: {
-                int iii = 1;            }
+                int iii = 1;
+            }
             ;
             ;
 
@@ -382,7 +384,8 @@ case 2:if (t instanceof Base) {
             public int compare(Object o1, Object o2) {
                 try {
                     A<Integer> a = new <String>A<Integer>(new Integer(11), "foo") {
-                    };                }
+                    };
+                }
                 catch (Exception e) {
                 }
 
@@ -393,7 +396,8 @@ case 2:if (t instanceof Base) {
             public boolean equals(Object obj) {
                 return super.equals(obj);
             }
-        };    }
+        };
+    }
 
     private static InputStream createInputStream() {
         return new ByteArrayInputStream(null);

--- a/tests/output/java8_concepts
+++ b/tests/output/java8_concepts
@@ -142,7 +142,7 @@ public class JavaConcepts<T extends List<int[]> , X> extends Base implements Ser
             }
         }
         ;
-        native void nnn() ;
+        native void nnn();
 
         transient int x;
 
@@ -150,7 +150,7 @@ public class JavaConcepts<T extends List<int[]> , X> extends Base implements Ser
             this.x = x;
         }
 
-        abstract void mm() ;
+        abstract void mm();
     }
 
     strictfp double ddd() {
@@ -255,7 +255,7 @@ case 2:if (t instanceof Base) {
         }
     }
 
-    public static void main(String[] args) throws ParseException, IOException {
+    public static void main(String[] args) throws ParseException, IOException  {
         int x = 2;
         CompilationUnit cu = parse(new File("src/japa/parser/javacc/Parser.java"));
         System.out.println(cu);
@@ -301,7 +301,7 @@ case 2:if (t instanceof Base) {
         }
     }
 
-    public static CompilationUnit parse(@Deprecated File file) throws ParseException, IOException {
+    public static CompilationUnit parse(@Deprecated File file) throws ParseException, IOException  {
         String a = ((String)"qwe");
         String x = ((String)clz1.getName());
         int y = ((Integer)(Object)x).intValue();
@@ -379,7 +379,7 @@ case 2:if (t instanceof Base) {
         }
     }
 
-    private <Y> void x(Map<? extends X, ? super T> x){
+    private <Y> void x(Map<? extends X, ? super T> x) {
         @Deprecated Comparator c = new Comparator() {
             public int compare(Object o1, Object o2) {
                 try {
@@ -405,7 +405,7 @@ case 2:if (t instanceof Base) {
 }
 
 class Base {
-    public <A, B> void check2(A val1, B val2){
+    public <A, B> void check2(A val1, B val2) {
     }
 }
 

--- a/tests/output/java8_concepts
+++ b/tests/output/java8_concepts
@@ -319,12 +319,13 @@ public class JavaConcepts<T extends List<int[]> , X> extends Base implements Ser
         }
         catch (final NullPointerException e) {
             System.out.println("catch");
-        }        catch (RuntimeException e) {
+        }
+        catch (RuntimeException e) {
             System.out.println("catch");
-        }        finally {
+        }
+        finally {
             System.out.println("finally");
         }
-
 
         try {
             if (file == null) {
@@ -334,7 +335,6 @@ public class JavaConcepts<T extends List<int[]> , X> extends Base implements Ser
         finally {
             System.out.println("finally");
         }
-
 
         try {
             if (file == null) {
@@ -363,13 +363,13 @@ public class JavaConcepts<T extends List<int[]> , X> extends Base implements Ser
             System.out.println(in);
         }
 
-
         try {
             System.out.println("whatever");
         }
         catch (RuntimeException e) {
             System.out.println(e);
-        }        catch (final Exception | Error e) {
+        }
+        catch (final Exception | Error e) {
             System.out.println(e);
         }
 
@@ -412,5 +412,4 @@ class Base {
 }
 
 interface XXX extends Serializable, Cloneable {
-
 }

--- a/tests/output/java8_concepts
+++ b/tests/output/java8_concepts
@@ -113,52 +113,44 @@ public class JavaConcepts<T extends List<int[]> , X> extends Base implements Ser
     }
 
     public enum Teste {
-asc,
-def
-}
-
-    public enum Sexo {
-m,
-@Deprecated f
-;
-
-    public enum Sexo_ implements Serializable, Cloneable {
-
-}
-
-    private Sexo() {
+        asc,
+        def
     }
 
+    public enum Sexo {
+        m,
+        @Deprecated f
+        ;
+        public enum Sexo_ implements Serializable, Cloneable {
 
-}
+        }
+
+        private Sexo() {
+        }
+    }
 
     @Deprecated
     public enum Enum {
-m(1){
-        @Override
-        void mm() {
+        m(1) {
+            @Override
+            void mm() {
+            }
+        },
+        f(2) {
+            void mm() {
+            }
         }
-    }
-,
-f(2){
-        void mm() {
+        ;
+        native void nnn() ;
+
+        transient int x;
+
+        private Enum(int x) {
+            this.x = x;
         }
+
+        abstract void mm() ;
     }
-
-;
-
-    native void nnn() ;
-
-    transient int x;
-
-    private Enum(int x) {
-        this.x = x;
-    }
-
-    abstract void mm() ;
-
-
-}
 
     strictfp double ddd() {
         return 0.0;

--- a/tests/output/java8_concepts
+++ b/tests/output/java8_concepts
@@ -232,21 +232,24 @@ public class JavaConcepts<T extends List<int[]> , X> extends Base implements Ser
             long sl = 123123123123l;
             long minl = -9223372036854775808L;
             switch (i) {
-}
+            }
             ll: switch (i) {
-case 1:System.out.println(1);
-            break ll;
-default:{
-                System.out.println("default");
-                break;
-            }
-case 2:if (t instanceof Base) {
-                System.out.println(1);
-            }
+                case 1:
+                    System.out.println(1);
+                    break ll;
+                default:
+                    {
+                        System.out.println("default");
+                        break;
+                    }
+                case 2:
+                    if (t instanceof Base) {
+                        System.out.println(1);
+                    }
 
-            i++;
-            ++i;
-}
+                    i++;
+                    ++i;
+            }
         }
 
         private synchronized int doSomething()[] {

--- a/tests/output/java8_interface
+++ b/tests/output/java8_interface
@@ -1,0 +1,5 @@
+package com.konjex.util.provide;
+
+public interface Providable<MatchType> extends DataClass {
+    MatchType getProviderKey();
+}

--- a/tests/spec/java8
+++ b/tests/spec/java8
@@ -270,7 +270,7 @@ id      ^ID
 #----------------------------------------------------------------------------------------------------------------------#
 
 cmp_unit
-    -> [package_decl] [import_decls] [type_decls];
+    -> [package_decl] [import_decls] [type_decls] `{}{}{;indent=    }`;
 
 package_decl
     -> [annotations] PACKAGE id_chain SEMI `{}{} {}{}\n\n`;
@@ -309,9 +309,9 @@ superinterfaces
     -> IMPLEMENTS class_type_list `{} {} `;
 
 class_body
-    -> LBRACE [class_body_decs] RBRACE `{}\n{;prefix=[prefix]    }[prefix]{}\n`;
+    -> LBRACE [class_body_decs] RBRACE `{}\n{;prefix=[prefix][indent]}[prefix]{}\n`;
 inline_class_body
-    -> LBRACE [class_body_decs] RBRACE ` {}\n{;prefix=[prefix]    }[prefix]{}`;
+    -> LBRACE [class_body_decs] RBRACE ` {}\n{;prefix=[prefix][indent]}[prefix]{}`;
 class_body_decs
     -> class_body_dec class_body_decs `[prefix]{}\n{}`
     -> class_body_dec `[prefix]{}`;
@@ -333,7 +333,8 @@ class_member_dec
 constructor_dec
     -> modifiers_opt constructor_declarator [throws] constructor_body `{}{} {}{}`;
 constructor_body
-    -> LBRACE explicit_constructor_invocation_opt [prefixed_block_statements] RBRACE `{}\n{;prefix=[prefix]    }{;prefix=[prefix]    }[prefix]{}\n`;
+    -> LBRACE explicit_constructor_invocation_opt [prefixed_block_statements] RBRACE
+        `{}\n{;prefix=[prefix][indent]}{;prefix=[prefix][indent]}[prefix]{}\n`;
 constructor_declarator
     -> [type_parameters] ID LPAREN [formal_parameter_list] RPAREN;
 
@@ -404,18 +405,19 @@ enum_dec
     -> modifiers_opt ENUM ID [superinterfaces] enum_body `{}{} {} {}{}`;
 
 enum_body
-    -> LBRACE [enum_const_list] [COMMA] [enum_body_declarations] RBRACE `{}\n{}{}\n{}{}\n`;
+    -> LBRACE [enum_const_list] [COMMA] [enum_body_declarations] RBRACE
+        `{}\n{;prefix=[prefix][indent]}{}\n{;prefix=[prefix][indent]}[prefix]{}\n`;
 
 enum_const_list
-    -> enum_const COMMA enum_const_list `{}{}\n{}`
-    -> enum_const;
+    -> enum_const COMMA enum_const_list `[prefix]{}{}\n{}`
+    -> enum_const `[prefix]{}`;
 enum_const
-    -> [annotations] ID [enum_const_arg_list] [class_body];
+    -> [annotations] ID [enum_const_arg_list] [inline_class_body];
 enum_const_arg_list
     -> LPAREN [argument_list] RPAREN;
 
 enum_body_declarations
-    -> SEMI [class_body_decs] `{}\n\n{}\n\n`;
+    -> SEMI [class_body_decs] `[prefix]{}\n{}`;
 
 #
 # INTERFACE
@@ -597,7 +599,7 @@ array_initializer
     -> LBRACE [variable_initializers] [COMMA] RBRACE;
 
 block
-    -> LBRACE [prefixed_block_statements] RBRACE `{}\n{;prefix=[prefix]    }[prefix]{}`;
+    -> LBRACE [prefixed_block_statements] RBRACE `{}\n{;prefix=[prefix][indent]}[prefix]{}`;
 
 #
 # STATEMENTS

--- a/tests/spec/java8
+++ b/tests/spec/java8
@@ -300,16 +300,16 @@ type_decl
 
 class_dec
     -> modifiers_opt CLASS ID [type_parameters] [superclass] [superinterfaces] class_body
-        `{}{} {}{} {}{}{}`;
+        `{}{} {}{}{}{}{}`;
 
 superclass
-    -> EXTENDS class_type `{} {} `;
+    -> EXTENDS class_type ` {} {}`;
 
 superinterfaces
-    -> IMPLEMENTS class_type_list `{} {} `;
+    -> IMPLEMENTS class_type_list ` {} {}`;
 
 class_body
-    -> LBRACE [class_body_decs] RBRACE `{}\n{;prefix=[prefix][indent]}[prefix]{}\n`;
+    -> inline_class_body `{}\n`;
 inline_class_body
     -> LBRACE [class_body_decs] RBRACE ` {}\n{;prefix=[prefix][indent]}[prefix]{}`;
 class_body_decs
@@ -333,19 +333,10 @@ class_member_dec
 constructor_dec
     -> modifiers_opt constructor_declarator [throws] constructor_body `{}{} {}{}`;
 constructor_body
-    -> LBRACE explicit_constructor_invocation_opt [prefixed_block_statements] RBRACE
-        `{}\n{;prefix=[prefix][indent]}{;prefix=[prefix][indent]}[prefix]{}\n`;
+    -> LBRACE constructor_statements RBRACE
+        `{}\n{;prefix=[prefix][indent]}[prefix]{}\n`;
 constructor_declarator
     -> [type_parameters] ID LPAREN [formal_parameter_list] RPAREN;
-
-explicit_constructor_invocation_opt
-    -> explicit_constructor_invocation `[prefix]{}\n\n`
-    ->;
-explicit_constructor_invocation
-    -> [type_arguments] THIS LPAREN [argument_list] RPAREN SEMI
-    -> [type_arguments] SUPER LPAREN [argument_list] RPAREN SEMI
-    -> expr_name DOT [type_arguments] SUPER LPAREN [argument_list] RPAREN SEMI
-    -> primary DOT [type_arguments] SUPER LPAREN [argument_list] RPAREN SEMI;
 
 argument_list
     -> expr COMMA argument_list `{}{} {}`
@@ -380,7 +371,7 @@ receiver_parameter
     -> [annotations] type ID DOT THIS `{}{} {}{}{}`
     -> [annotations] type THIS `{}{} {}`;
 last_formal_parameter
-    -> modifiers_opt type [annotations] TRIDOT variable_declarator_id `{}{}{} {}`
+    -> modifiers_opt type [annotations] TRIDOT variable_declarator_id `{}{}{}{} {}`
     -> formal_parameter;
 
 throws
@@ -586,7 +577,7 @@ variable_declarator_id
     -> ID [array_dims];
 
 variable_initializers
-    -> variable_initializer COMMA variable_initializers
+    -> variable_initializer COMMA variable_initializers `{}{} {}`
     -> variable_initializer;
 variable_initializer_opt
     -> ASSN variable_initializer ` {} {}`
@@ -778,6 +769,17 @@ for_update
 enhanced_for_statement
     -> FOR LPAREN modifiers_opt type variable_declarator_id COLON expr RPAREN `{} {}{}{} {} {} {}{}`;
 
+constructor_statements
+    -> [prefixed_block_statements]
+    -> explicit_constructor_invocation_statement prefixed_block_statements `[prefix]{}\n\n{}`
+    -> explicit_constructor_invocation_statement `[prefix]{}\n`;
+
+explicit_constructor_invocation_statement
+    -> [type_arguments] THIS LPAREN [argument_list] RPAREN SEMI
+    -> [type_arguments] SUPER LPAREN [argument_list] RPAREN SEMI
+    -> expr_name DOT [type_arguments] SUPER LPAREN [argument_list] RPAREN SEMI
+    -> primary DOT [type_arguments] SUPER LPAREN [argument_list] RPAREN SEMI;
+
 #
 # EXPRESSIONS
 #
@@ -935,10 +937,12 @@ method_reference
     -> array_type M_REF NEW;
 
 array_creation_expr
-    -> NEW PRIM dim_exprs [array_dims]
-    -> NEW class_type dim_exprs [array_dims]
-    -> NEW PRIM array_dims array_initializer
-    -> NEW class_type array_dims array_initializer;
+    -> array_creation_type dim_exprs [array_dims]
+    -> array_creation_type array_dims array_initializer;
+
+array_creation_type
+    -> NEW PRIM `{} {}`
+    -> NEW class_type `{} {}`;
 
 dim_exprs
     -> dim_expr dim_exprs

--- a/tests/spec/java8
+++ b/tests/spec/java8
@@ -601,8 +601,8 @@ prefixed_block_statements
 block_statements
     -> isolated_block_statement block_statements `{}\n[prefix]{}`
     -> grouped_statements isolated_block_statement block_statements `{}\n\n[prefix]{}\n[prefix]{}`
-    -> grouped_statements isolated_block_statement `{}\n\n[prefix]{}`
-    -> isolated_block_statement
+    -> grouped_statements inline_isolated_block_statement `{}\n\n[prefix]{}\n`
+    -> inline_isolated_block_statement `{}\n`
     -> grouped_statements `{}\n`;
 
 isolated_block_statement
@@ -610,6 +610,12 @@ isolated_block_statement
     -> block `{}\n`
     -> lvar_dec_statement
     -> isolated_statement `{}\n`;
+
+inline_isolated_block_statement
+    -> class_dec
+    -> block
+    -> lvar_dec_statement
+    -> isolated_statement;
 
 lvar_dec_statement
     -> lvar_dec SEMI;

--- a/tests/spec/java8
+++ b/tests/spec/java8
@@ -423,7 +423,7 @@ extends_interfaces
     -> EXTENDS class_type_list `{} {} `;
 
 interface_body
-    -> LBRACE [interface_member_decs] RBRACE `{}\n\n{}{}\n`;
+    -> LBRACE [interface_member_decs] RBRACE `{}\n{}{}\n`;
 
 interface_member_decs
     -> class_member_dec interface_member_decs `{}\n\n{}`
@@ -716,25 +716,28 @@ throw_statement
     -> THROW expr SEMI `{} {}{}`;
 
 try_statement
-    -> TRY block catches `{} {}\n{}`
-    -> TRY block [catches] finally `{} {}\n{}[prefix]{}`
-    -> try_with_resources_statement;
+    -> try_header
+    -> try_header catches `{}\n{}`
+    -> try_header finally `{}\n{}`
+    -> try_header catches finally `{}\n{}\n{}`;
 
-try_with_resources_statement
-    -> TRY resources_specification block [catches] [finally] `{} {} {}\n{}{}`;
+try_header
+    -> TRY block `{} {}`
+    -> TRY resources_specification block `{} {} {}`;
+
 resources_specification
     -> LPAREN resources [SEMI] RPAREN;
 resources
     -> resource SEMI resources `{}{} {}`
     -> resource;
 resource
-    -> modifiers_opt type variable_declarator_id ASSN expr `{}{} {} {} {}`;
+    -> [inline_modifiers] type variable_declarator_id ASSN expr `{}{} {} {} {}`;
 
 finally
-    -> FINALLY block `{} {}\n`;
+    -> FINALLY block `[prefix]{} {}`;
 
 catches
-    -> catch_clause catches `[prefix]{}{}`
+    -> catch_clause catches `[prefix]{}\n{}`
     -> catch_clause `[prefix]{}`;
 catch_clause
     -> CATCH LPAREN catch_formal_parameter RPAREN block `{} {}{}{} {}`;

--- a/tests/spec/java8
+++ b/tests/spec/java8
@@ -656,7 +656,7 @@ isolated_statement
     -> try_statement;
 
 statement_expression_list
-    -> statement_expression COMMA statement_expression_list
+    -> statement_expression COMMA statement_expression_list `{}{} {}`
     -> statement_expression;
 statement_expression
     -> assignment
@@ -695,7 +695,7 @@ switch_label
     -> DEFAULT COLON `[prefix]{}{}`;
 
 do_statement
-    -> DO statement WHILE LPAREN expr RPAREN SEMI;
+    -> DO statement WHILE LPAREN expr RPAREN SEMI `{} {} {} {}{}{}{}`;
 
 break_statement
     -> BREAK SEMI
@@ -753,7 +753,7 @@ if_then_statement
     -> IF LPAREN expr RPAREN statement `{} {}{}{} {}`;
 
 if_then_else_statement
-    -> IF LPAREN expr RPAREN inline_statement ELSE statement `{} {}{}{} {}{} {}`
+    -> IF LPAREN expr RPAREN inline_statement ELSE statement `{} {}{}{} {} {} {}`
     -> IF LPAREN expr RPAREN block ELSE statement `{} {}{}{} {}\n[prefix]{} {}`;
 
 while_statement
@@ -767,7 +767,7 @@ basic_for_statement
     -> FOR LPAREN [for_init] SEMI [for_expr] SEMI [for_update] RPAREN `{} {}{}{}{}{}{}{}`;
 
 for_init
-    -> lvar_dec
+    -> [inline_modifiers] type variable_declarator_list `{}{} {}`
     -> statement_expression_list;
 for_expr
     -> expr ` {}`;
@@ -970,7 +970,7 @@ annotation_modifiers
     -> annotation `{}\n[prefix]`;
 
 non_annotation_modifiers
-    -> first_modifier modifiers `{} {}`
+    -> first_modifier inline_modifiers `{} {}`
     -> first_modifier `{} `;
 first_modifier
     -> MOD
@@ -978,8 +978,8 @@ first_modifier
     -> STATIC
     -> FINAL
     -> DEFAULT;
-modifiers
-    -> modifier modifiers `{} {}`
+inline_modifiers
+    -> modifier inline_modifiers `{} {}`
     -> modifier `{} `;
 modifier
     -> annotation

--- a/tests/spec/java8
+++ b/tests/spec/java8
@@ -678,21 +678,21 @@ switch_statement
     -> SWITCH LPAREN expr RPAREN switch_block `{} {}{}{} {}`;
 
 switch_block
-    -> LBRACE [switch_bsgs] [switch_labels] RBRACE `{}\n{}{}{}`;
+    -> LBRACE [switch_bsgs] [switch_labels] RBRACE `{}\n{;prefix=[prefix][indent]}{;prefix=[prefix][indent]}[prefix]{}`;
 
 switch_bsgs
     -> switch_bsg switch_bsgs
     -> switch_bsg;
 switch_bsg
-    -> switch_labels block_statements;
+    -> switch_labels prefixed_block_statements `{}\n{;prefix=[prefix][indent]}`;
 
 switch_labels
     -> switch_label switch_labels
     -> switch_label;
 switch_label
-    -> CASE expr COLON `{} {}{}`
-    -> CASE ID COLON `{} {}{}`
-    -> DEFAULT COLON;
+    -> CASE expr COLON `[prefix]{} {}{}`
+    -> CASE ID COLON `[prefix]{} {}{}`
+    -> DEFAULT COLON `[prefix]{}{}`;
 
 do_statement
     -> DO statement WHILE LPAREN expr RPAREN SEMI;

--- a/tests/spec/java8
+++ b/tests/spec/java8
@@ -423,11 +423,11 @@ extends_interfaces
     -> EXTENDS class_type_list `{} {} `;
 
 interface_body
-    -> LBRACE [interface_member_decs] RBRACE `{}\n{}{}\n`;
+    -> LBRACE [interface_member_decs] RBRACE `{}\n{;prefix=[prefix][indent]}{}\n`;
 
 interface_member_decs
-    -> class_member_dec interface_member_decs `{}\n\n{}`
-    -> class_member_dec `{}\n\n`;
+    -> class_member_dec interface_member_decs `[prefix]{}\n{}`
+    -> class_member_dec `[prefix]{}`;
 
 #
 # ANNOTATION
@@ -437,17 +437,17 @@ annotation_dec
     -> modifiers_opt AT INTERFACE ID annotation_body `{}{}{} {} {}`;
 
 annotation_body
-    -> LBRACE [annotation_member_decs] RBRACE `{}\n\n{}{}\n`;
+    -> LBRACE [annotation_member_decs] RBRACE `{}\n{;prefix=[prefix][indent]}{}\n`;
 
 annotation_member_decs
-    -> annotation_member_dec annotation_member_decs `{}\n\n{}`
-    -> annotation_member_dec `{}\n\n`;
+    -> annotation_member_dec annotation_member_decs `[prefix]{}\n{}`
+    -> annotation_member_dec `[prefix]{}`;
 annotation_member_dec
     -> annotation_element_dec
     -> class_member_dec;
 
 annotation_element_dec
-    -> modifiers_opt type ID LPAREN RPAREN [array_dims] [default_value] SEMI `{}{} {}{}{}{}{}{}`;
+    -> modifiers_opt type ID LPAREN RPAREN [array_dims] [default_value] SEMI `{}{} {}{}{}{}{}{}\n`;
 
 default_value
     -> DEFAULT element_value ` {} {}`;

--- a/tests/spec/java8
+++ b/tests/spec/java8
@@ -348,13 +348,15 @@ field_dec
 method_dec
     -> modifiers_opt method_header method_body `{}{}{}\n`;
 method_header
-    -> result method_declarator [throws] `{} {} {}`
-    -> type_parameters [annotations] result method_declarator [throws] `{} {}{} {}{}`;
+    -> result method_declarator [method_throws] `{} {}{}`
+    -> type_parameters [annotations] result method_declarator [method_throws] `{} {}{} {}{}`;
 method_declarator
     -> ID LPAREN [formal_parameter_list] RPAREN [array_dims];
 method_body
-    -> block
+    -> block ` {}`
     -> SEMI;
+method_throws
+    -> throws ` {}`;
 
 formal_parameter_list
     -> receiver_parameter


### PR DESCRIPTION
Fixed issues when formatting:
--
- enum, interface, and annotation declarations
- array instance creation
- variadic parameters
- method declaration throws
- switch, do, if, for, and try-catch-finally statements

closes #39 