### PR TITLE
Forced formatting for inline if/else/do/while/for statements

### DIFF
--- a/tests/input/java8_inline
+++ b/tests/input/java8_inline
@@ -1,0 +1,99 @@
+package com.padd.tests;
+
+public class InlineStatements {
+    public void test() {
+        // Normal if-then
+        if (x) {
+            call();
+            call();
+            call();
+            int x = y;
+        }
+
+        // Inline if-then
+        if (x) call();
+
+        // Normal if-then-else
+        if (x) {
+            call();
+            call();
+        } else {
+            call();
+            call();
+        }
+
+        // Inline if-then-else
+        if (x) call(); else call();
+
+        if (x) {
+            call();
+        } else call();
+
+        if (x) call(); else {
+            call();
+        }
+
+        // Normal if-then-else if
+        if (x) {
+            call();
+        } else if (y) {
+            call();
+        } else if (z) {
+            call();
+        } else {
+            call();
+        }
+
+        // Inline if-then-else if
+        if (x) call();
+        else if (y) call();
+        else if (z) call();
+        else call();
+
+        if (x) call();
+        else if (y) {
+            call();
+        } else if (z) {
+            call();
+        } else {
+            call();
+        }
+
+        if (x) {
+            call();
+        } else if (y) call();
+        else if (z) {
+            call();
+        } else call();
+
+        // Normal while
+        while (x) {
+            call();
+        }
+
+        // Inline while
+        while (x) call();
+
+        // Normal do-while
+        do {
+            call();
+        } while(x);
+
+        // Inline do-while
+        do call(); while(x);
+
+        // Normal for
+        for (int i = 0; i < x; ++i) {
+            call();
+        }
+
+        for (Object o : objects) {
+            call();
+        }
+
+        // Inline for
+        for (int i = 0; i < x; ++i) call();
+
+        for (Object o : objects) call();
+    }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -98,6 +98,11 @@ fn test_java8_interface() {
 }
 
 #[test]
+fn test_java8_inline() {
+    test_fjr("java8_inline", "java8");
+}
+
+#[test]
 fn test_ignore_tokens() {
     //setup
     let spec = "

--- a/tests/output/java8_complex_spring
+++ b/tests/output/java8_complex_spring
@@ -62,19 +62,15 @@ public final class CollectionFactory {
     public static <E> Collection<E> createApproximateCollection(@Nullable Object collection, int capacity) {
         if (collection instanceof LinkedList) {
             return new LinkedList<>();
-        }
-        else if (collection instanceof List) {
+        } else if (collection instanceof List) {
             return new ArrayList<>(capacity);
-        }
-        else if (collection instanceof EnumSet) {
+        } else if (collection instanceof EnumSet) {
             Collection<E> enumSet = (Collection<E>)EnumSet.copyOf((EnumSet)collection);
             enumSet.clear();
             return enumSet;
-        }
-        else if (collection instanceof SortedSet) {
+        } else if (collection instanceof SortedSet) {
             return new TreeSet<>(((SortedSet<E>)collection).comparator());
-        }
-        else {
+        } else {
             return new LinkedHashSet<>(capacity);
         }
     }
@@ -90,22 +86,17 @@ public final class CollectionFactory {
         if (collectionType.isInterface()) {
             if (Set.class == collectionType || Collection.class == collectionType) {
                 return new LinkedHashSet<>(capacity);
-            }
-            else if (List.class == collectionType) {
+            } else if (List.class == collectionType) {
                 return new ArrayList<>(capacity);
-            }
-            else if (SortedSet.class == collectionType || NavigableSet.class == collectionType) {
+            } else if (SortedSet.class == collectionType || NavigableSet.class == collectionType) {
                 return new TreeSet<>();
-            }
-            else {
+            } else {
                 throw new IllegalArgumentException("Unsupported Collection interface: " + collectionType.getName());
             }
-        }
-        else if (EnumSet.class == collectionType) {
+        } else if (EnumSet.class == collectionType) {
             Assert.notNull(elementType, "Cannot create EnumSet for unknown element type");
             return (Collection<E>)EnumSet.noneOf(asEnumType(elementType));
-        }
-        else {
+        } else {
             if (!Collection.class.isAssignableFrom(collectionType)) {
                 throw new IllegalArgumentException("Unsupported Collection type: " + collectionType.getName());
             }
@@ -129,11 +120,9 @@ public final class CollectionFactory {
             EnumMap enumMap = new EnumMap((EnumMap)map);
             enumMap.clear();
             return enumMap;
-        }
-        else if (map instanceof SortedMap) {
+        } else if (map instanceof SortedMap) {
             return new TreeMap<>(((SortedMap<K, V>)map).comparator());
-        }
-        else {
+        } else {
             return new LinkedHashMap<>(capacity);
         }
     }
@@ -149,22 +138,17 @@ public final class CollectionFactory {
         if (mapType.isInterface()) {
             if (Map.class == mapType) {
                 return new LinkedHashMap<>(capacity);
-            }
-            else if (SortedMap.class == mapType || NavigableMap.class == mapType) {
+            } else if (SortedMap.class == mapType || NavigableMap.class == mapType) {
                 return new TreeMap<>();
-            }
-            else if (MultiValueMap.class == mapType) {
+            } else if (MultiValueMap.class == mapType) {
                 return new LinkedMultiValueMap();
-            }
-            else {
+            } else {
                 throw new IllegalArgumentException("Unsupported Map interface: " + mapType.getName());
             }
-        }
-        else if (EnumMap.class == mapType) {
+        } else if (EnumMap.class == mapType) {
             Assert.notNull(keyType, "Cannot create EnumMap for unknown key type");
             return new EnumMap(asEnumType(keyType));
-        }
-        else {
+        } else {
             if (!Map.class.isAssignableFrom(mapType)) {
                 throw new IllegalArgumentException("Unsupported Map type: " + mapType.getName());
             }

--- a/tests/output/java8_complex_spring
+++ b/tests/output/java8_complex_spring
@@ -103,8 +103,7 @@ public final class CollectionFactory {
 
             try {
                 return (Collection<E>)ReflectionUtils.accessibleConstructor(collectionType).newInstance();
-            }
-            catch (Throwable ex) {
+            } catch (Throwable ex) {
                 throw new IllegalArgumentException("Could not instantiate Collection type: " + collectionType.getName(), ex);
             }
         }
@@ -155,8 +154,7 @@ public final class CollectionFactory {
 
             try {
                 return (Map<K, V>)ReflectionUtils.accessibleConstructor(mapType).newInstance();
-            }
-            catch (Throwable ex) {
+            } catch (Throwable ex) {
                 throw new IllegalArgumentException("Could not instantiate Map type: " + mapType.getName(), ex);
             }
         }

--- a/tests/output/java8_concepts
+++ b/tests/output/java8_concepts
@@ -233,6 +233,7 @@ public class JavaConcepts<T extends List<int[]> , X> extends Base implements Ser
             long minl = -9223372036854775808L;
             switch (i) {
             }
+
             ll: switch (i) {
                 case 1:
                     System.out.println(1);
@@ -268,26 +269,40 @@ public class JavaConcepts<T extends List<int[]> , X> extends Base implements Ser
         if (1 + 1 == 2) {
             teste = null;
             teste = new JavaConcepts(1);
-        }
-        else {
+        } else {
             x = 3;
             teste = new JavaConcepts(1);
             x = x == 0 ? 2 : 4;
         }
 
-        if (true) x = 1; else x = 3;
+        if (true) {
+            x = 1;
+        } else {
+            x = 3;
+        }
 
-        if (true) x = 1; else if (false) x = 3; else x = 2;
+        if (true) {
+            x = 1;
+        } else if (false) {
+            x = 3;
+        } else {
+            x = 2;
+        }
 
         while (true) {
-            xxx: while (x == 3) continue xxx;
+            xxx: while (x == 3) {
+                continue xxx;
+            }
             break;
         }
 
         do {
             x++;
         } while (x < 100);
-        do x++; while (x < 100);
+
+        do {
+            x++;
+        } while (x < 100);
 
         for (@Deprecated int i : arr4[0]) {
             x--;
@@ -316,14 +331,11 @@ public class JavaConcepts<T extends List<int[]> , X> extends Base implements Ser
             if (file == null) {
                 throw new NullPointerException("blah");
             }
-        }
-        catch (final NullPointerException e) {
+        } catch (final NullPointerException e) {
             System.out.println("catch");
-        }
-        catch (RuntimeException e) {
+        } catch (RuntimeException e) {
             System.out.println("catch");
-        }
-        finally {
+        } finally {
             System.out.println("finally");
         }
 
@@ -331,8 +343,7 @@ public class JavaConcepts<T extends List<int[]> , X> extends Base implements Ser
             if (file == null) {
                 throw new NullPointerException("blah");
             }
-        }
-        finally {
+        } finally {
             System.out.println("finally");
         }
 
@@ -340,22 +351,19 @@ public class JavaConcepts<T extends List<int[]> , X> extends Base implements Ser
             if (file == null) {
                 throw new NullPointerException("blah");
             }
-        }
-        catch (RuntimeException e) {
+        } catch (RuntimeException e) {
             System.out.println("catch");
         }
 
         try (InputStream in = createInputStream()) {
             System.out.println(in);
-        }
-        catch (IOException e) {
+        } catch (IOException e) {
             System.out.println("catch");
         }
 
         try (InputStream in = createInputStream(); InputStream in2 = createInputStream()) {
             System.out.println(in);
-        }
-        catch (IOException e) {
+        } catch (IOException e) {
             System.out.println("catch");
         }
 
@@ -365,11 +373,9 @@ public class JavaConcepts<T extends List<int[]> , X> extends Base implements Ser
 
         try {
             System.out.println("whatever");
-        }
-        catch (RuntimeException e) {
+        } catch (RuntimeException e) {
             System.out.println(e);
-        }
-        catch (final Exception | Error e) {
+        } catch (final Exception | Error e) {
             System.out.println(e);
         }
 
@@ -387,8 +393,7 @@ public class JavaConcepts<T extends List<int[]> , X> extends Base implements Ser
                 try {
                     A<Integer> a = new <String>A<Integer>(new Integer(11), "foo") {
                     };
-                }
-                catch (Exception e) {
+                } catch (Exception e) {
                 }
 
                 return 0;

--- a/tests/output/java8_inline
+++ b/tests/output/java8_inline
@@ -1,0 +1,115 @@
+package com.padd.tests;
+
+public class InlineStatements {
+    public void test() {
+        if (x) {
+            call();
+            call();
+            call();
+
+            int x = y;
+        }
+
+        if (x) {
+            call();
+        }
+
+        if (x) {
+            call();
+            call();
+        } else {
+            call();
+            call();
+        }
+
+        if (x) {
+            call();
+        } else {
+            call();
+        }
+
+        if (x) {
+            call();
+        } else {
+            call();
+        }
+
+        if (x) {
+            call();
+        } else {
+            call();
+        }
+
+        if (x) {
+            call();
+        } else if (y) {
+            call();
+        } else if (z) {
+            call();
+        } else {
+            call();
+        }
+
+        if (x) {
+            call();
+        } else if (y) {
+            call();
+        } else if (z) {
+            call();
+        } else {
+            call();
+        }
+
+        if (x) {
+            call();
+        } else if (y) {
+            call();
+        } else if (z) {
+            call();
+        } else {
+            call();
+        }
+
+        if (x) {
+            call();
+        } else if (y) {
+            call();
+        } else if (z) {
+            call();
+        } else {
+            call();
+        }
+
+        while (x) {
+            call();
+        }
+
+        while (x) {
+            call();
+        }
+
+        do {
+            call();
+        } while (x);
+
+        do {
+            call();
+        } while (x);
+
+        for (int i = 0; i < x; ++i) {
+            call();
+        }
+
+        for (Object o : objects) {
+            call();
+        }
+
+        for (int i = 0; i < x; ++i) {
+            call();
+        }
+
+        for (Object o : objects) {
+            call();
+        }
+    }
+}

--- a/tests/spec/java8
+++ b/tests/spec/java8
@@ -628,9 +628,17 @@ statement
     -> block
     -> inline_statement;
 
+forced_statement
+    -> block
+    -> inline_statement `\\{\n[prefix][indent]{;prefix=[prefix][indent]}\n[prefix]\\}`;
+
 inline_statement
     -> grouped_statement
     -> isolated_statement;
+
+inline_statement_no_if
+    -> grouped_statement
+    -> isolated_statement_no_if;
 
 grouped_statements
     -> grouped_statement grouped_statements `{}\n[prefix]{}`
@@ -640,20 +648,22 @@ grouped_statement
     -> SEMI
     -> statement_expression SEMI
     -> assert_statement
-    -> switch_statement
-    -> do_statement
     -> break_statement
     -> continue_statement
     -> return_statement
     -> throw_statement;
 
 isolated_statement
-    -> if_then_statement
-    -> if_then_else_statement
+    -> if_statement
+    -> isolated_statement_no_if;
+
+isolated_statement_no_if
     -> while_statement
     -> for_statement
     -> synchronized_statement
-    -> try_statement;
+    -> try_statement
+    -> do_statement
+    -> switch_statement;
 
 statement_expression_list
     -> statement_expression COMMA statement_expression_list `{}{} {}`
@@ -694,9 +704,6 @@ switch_label
     -> CASE ID COLON `[prefix]{} {}{}`
     -> DEFAULT COLON `[prefix]{}{}`;
 
-do_statement
-    -> DO statement WHILE LPAREN expr RPAREN SEMI `{} {} {} {}{}{}{}`;
-
 break_statement
     -> BREAK SEMI
     -> BREAK ID SEMI `{} {}{}`;
@@ -717,9 +724,9 @@ throw_statement
 
 try_statement
     -> try_header
-    -> try_header catches `{}\n{}`
-    -> try_header finally `{}\n{}`
-    -> try_header catches finally `{}\n{}\n{}`;
+    -> try_header catches `{} {}`
+    -> try_header finally `{} {}`
+    -> try_header catches finally `{} {} {}`;
 
 try_header
     -> TRY block `{} {}`
@@ -734,11 +741,11 @@ resource
     -> [inline_modifiers] type variable_declarator_id ASSN expr `{}{} {} {} {}`;
 
 finally
-    -> FINALLY block `[prefix]{} {}`;
+    -> FINALLY block `{} {}`;
 
 catches
-    -> catch_clause catches `[prefix]{}\n{}`
-    -> catch_clause `[prefix]{}`;
+    -> catch_clause catches `{} {}`
+    -> catch_clause `{}`;
 catch_clause
     -> CATCH LPAREN catch_formal_parameter RPAREN block `{} {}{}{} {}`;
 catch_formal_parameter
@@ -752,19 +759,33 @@ catch_type_internal
 labeled_statement
     -> ID COLON statement `{}{} {}`;
 
+if_statement
+    -> if_then_statement
+    -> if_then_else_statement;
+
 if_then_statement
-    -> IF LPAREN expr RPAREN statement `{} {}{}{} {}`;
+    -> IF LPAREN expr RPAREN forced_statement `{} {}{}{} {}`;
 
 if_then_else_statement
-    -> IF LPAREN expr RPAREN inline_statement ELSE statement `{} {}{}{} {} {} {}`
-    -> IF LPAREN expr RPAREN block ELSE statement `{} {}{}{} {}\n[prefix]{} {}`;
+    -> IF LPAREN expr RPAREN inline_statement ELSE else_statement
+        `{} {}{}{} \\{\n[prefix][indent]{;prefix=[prefix][indent]}\n[prefix]\\} {} {}`
+    -> IF LPAREN expr RPAREN block ELSE else_statement `{} {}{}{} {} {} {}`;
+
+else_statement
+    -> block
+    -> inline_statement_no_if `\\{\n[prefix][indent]{;prefix=[prefix][indent]}\n[prefix]\\}`
+    -> if_statement;
 
 while_statement
-    -> WHILE LPAREN expr RPAREN statement `{} {}{}{} {}`;
+    -> WHILE LPAREN expr RPAREN inline_statement `{} {}{}{} \\{\n[prefix][indent]{;prefix=[prefix][indent]}\n[prefix]\\}`
+    -> WHILE LPAREN expr RPAREN block `{} {}{}{} {}`;
+
+do_statement
+    -> DO forced_statement WHILE LPAREN expr RPAREN SEMI `{} {} {} {}{}{}{}`;
 
 for_statement
-    -> basic_for_statement statement `{} {}`
-    -> enhanced_for_statement statement `{} {}`;
+    -> basic_for_statement forced_statement `{} {}`
+    -> enhanced_for_statement forced_statement `{} {}`;
 
 basic_for_statement
     -> FOR LPAREN [for_init] SEMI [for_expr] SEMI [for_update] RPAREN `{} {}{}{}{}{}{}{}`;


### PR DESCRIPTION
- Automatically convert inline if/else/do/while/for to use blocks.
- Place else/catch/finally statements on the same line as the closing brace of their predecessor.