### PR TITLE
Use kcov for test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,17 +21,16 @@ env:
   global:
     - CODECOV_TOKEN=2072cbf1-2dcf-4982-b698-178d4b4047e4
 
-before_cache: |
-  if [[ "$TRAVIS_RUST_VERSION" == nightly ]]; then
-    RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin
-  fi
-
 after_success: |
-  if [[ "$TRAVIS_RUST_VERSION" == nightly ]]; then
+  if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
+    sudo apt-get update &&
     sudo apt-get install libcurl4-openssl-dev libelf-dev libdw-dev &&
     wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&
     tar xzf master.tar.gz && mkdir kcov-master/build && cd kcov-master/build && cmake .. && make &&
     sudo make install && cd ../.. &&
-    kcov --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo target/kcov target/debug/padd-*
+    for file in target/debug/padd-*[^\.d] target/debug/concept-*[^\.d] target/debug/scope-*[^\.d]; do
+      mkdir -p "target/cov/$(basename $file)";
+      kcov --exclude-region='#[cfg(test)]:#[cfg(testkcovstopmarker)]' --include-path=src --exclude-path=src/cli "target/cov/$(basename $file)" "$file";
+    done &&
     bash <(curl -s https://codecov.io/bash)
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,10 @@ before_cache: |
 
 after_success: |
   if [[ "$TRAVIS_RUST_VERSION" == nightly ]]; then
-    cargo tarpaulin --out Xml --ignore-tests --ignore-panics --exclude-files src/cli
+    sudo apt-get install libcurl4-openssl-dev libelf-dev libdw-dev &&
+    wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&
+    tar xzf master.tar.gz && mkdir kcov-master/build && cd kcov-master/build && cmake .. && make &&
+    sudo make install && cd ../.. &&
+    kcov --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo target/kcov target/debug/padd-*
     bash <(curl -s https://codecov.io/bash)
   fi


### PR DESCRIPTION
Kcov provides much more accurate and much faster code coverage generation than `cargo-tarpaulin`. Code coverage testing with kcov is fast enough that we can run coverage on stable which means we will still have coverage reports even if nightly is broken (as it is currently).