### PR TITLE
Added a formatter builder

### DIFF
--- a/src/core/fmt/pattern.rs
+++ b/src/core/fmt/pattern.rs
@@ -153,21 +153,25 @@ lazy_static! {
     };
 }
 
+#[derive(Clone)]
 pub struct Pattern {
     pub segments: Vec<Segment>,
 }
 
+#[derive(Clone)]
 pub enum Segment {
     Filler(String),
     Substitution(String),
     Capture(Capture),
 }
 
+#[derive(Clone)]
 pub struct Capture {
     pub child_index: usize,
     pub declarations: Vec<Declaration>,
 }
 
+#[derive(Clone)]
 pub struct Declaration {
     pub key: String,
     pub value: Option<Pattern>,


### PR DESCRIPTION
- Build `Formatter` at runtime with `FormatterBuilder`.
- `FormatterBuilder` has a memoization table so that duplicate patterns are only parsed once.
For small grammars, performance is very similar to the previous implementation. Performance increases should be seen in large grammars with many duplicated patterns.