### PR TITLE
Refactoring for better readability

### DIFF
--- a/src/core/data/stream.rs
+++ b/src/core/data/stream.rs
@@ -138,7 +138,10 @@ impl<'a, 'g: 'a, T: 'g + 'a + Clone> Stream<'a, 'g, T> {
         }
     }
 
-    pub fn consumer<'s>(&'s mut self, on_consume: Box<FnMut(&LinkedList<T>) + 's>) -> StreamConsumer<'s, 'a, 'g, T> {
+    pub fn consumer<'s>(
+        &'s mut self,
+        on_consume: Box<FnMut(&LinkedList<T>) + 's>,
+    ) -> StreamConsumer<'s, 'a, 'g, T> {
         StreamConsumer::new(self, on_consume)
     }
 
@@ -193,7 +196,10 @@ pub struct StreamConsumer<'s, 'a: 's, 'g: 'a + 's, T: 'g + 'a + 's + Clone> {
 
 #[allow(dead_code)]
 impl<'s, 'a: 's, 'g: 'a + 's, T: 'g + 'a + 's + Clone> StreamConsumer<'s, 'a, 'g, T> {
-    fn new(stream: &'s mut Stream<'a, 'g, T>, on_consume: Box<FnMut(&LinkedList<T>) + 's>) -> Self {
+    fn new(
+        stream: &'s mut Stream<'a, 'g, T>,
+        on_consume: Box<FnMut(&LinkedList<T>) + 's>,
+    ) -> Self {
         StreamConsumer {
             stream,
             on_consume,

--- a/src/core/data/stream.rs
+++ b/src/core/data/stream.rs
@@ -28,13 +28,10 @@ impl<'g, T: 'g + Clone> StreamSource<'g, T> {
     }
 
     pub fn detach_tail(&mut self) {
-        match self.buffers.pop_back() {
-            None => {}
-            Some(head) => {
-                self.buffers = LinkedList::new();
-                self.buffers.push_back(head);
-            }
-        };
+        if let Some(head) = self.buffers.pop_back() {
+            self.buffers = LinkedList::new();
+            self.buffers.push_back(head);
+        }
     }
 
     pub fn detach_head<'a>(&'a mut self) -> Stream<'a, 'g, T> {
@@ -58,9 +55,8 @@ impl<'g, T: 'g + Clone> StreamSource<'g, T> {
     }
 
     fn pull(&mut self) {
-        match (self.getter)() {
-            None => {}
-            Some(val) => for buffer in &mut self.buffers {
+        if let Some(val) = (self.getter)() {
+            for buffer in &mut self.buffers {
                 buffer.push(&val)
             }
         }
@@ -97,10 +93,9 @@ impl<T: Clone> StreamBuffer<T> {
     }
 
     fn advance(&mut self) {
-        match self.incoming_buffer.pop_back() {
-            None => {}
-            Some(val) => self.outgoing_buffer.push_back(val.clone())
-        };
+        if let Some(val) = self.incoming_buffer.pop_back() {
+            self.outgoing_buffer.push_back(val.clone())
+        }
     }
 
     fn replay(&mut self) {

--- a/src/core/fmt/mod.rs
+++ b/src/core/fmt/mod.rs
@@ -95,9 +95,8 @@ impl<'a> FormatJob<'a> {
         for seg in &pattern.segments {
             match seg {
                 &Segment::Filler(ref s) => res = format!("{}{}", res, s),
-                &Segment::Substitution(ref s) => match scope.get(s) {
-                    Some(value) => res = format!("{}{}", res, value),
-                    None => {}
+                &Segment::Substitution(ref s) => if let Some(value) = scope.get(s) {
+                    res = format!("{}{}", res, value);
                 },
                 &Segment::Capture(ref c) => res = format!("{}{}", res, self.evaluate_capture(c, children, scope)),
             };

--- a/src/core/fmt/mod.rs
+++ b/src/core/fmt/mod.rs
@@ -90,7 +90,12 @@ impl<'a> FormatJob<'a> {
         }
     }
 
-    fn fill_pattern(&self, pattern: &Pattern, children: &Vec<Tree>, scope: &HashMap<String, String>) -> String {
+    fn fill_pattern(
+        &self,
+        pattern: &Pattern,
+        children: &Vec<Tree>,
+        scope: &HashMap<String, String>,
+    ) -> String {
         let mut res: String = String::new();
         for seg in &pattern.segments {
             match seg {
@@ -98,19 +103,29 @@ impl<'a> FormatJob<'a> {
                 &Segment::Substitution(ref s) => if let Some(value) = scope.get(s) {
                     res = format!("{}{}", res, value);
                 },
-                &Segment::Capture(ref c) => res = format!("{}{}", res, self.evaluate_capture(c, children, scope)),
+                &Segment::Capture(ref c) => res = format!(
+                    "{}{}", res, self.evaluate_capture(c, children, scope)
+                ),
             };
         }
         res
     }
 
-    fn evaluate_capture(&self, capture: &Capture, children: &Vec<Tree>, outer_scope: &HashMap<String, String>) -> String {
+    fn evaluate_capture(
+        &self,
+        capture: &Capture,
+        children: &Vec<Tree>,
+        outer_scope: &HashMap<String, String>,
+    ) -> String {
         if capture.declarations.len() > 0 {
             let mut inner_scope = outer_scope.clone();
             for decl in &capture.declarations {
                 match &decl.value {
                     &Some(ref pattern) => {
-                        inner_scope.insert(decl.key.clone(), self.fill_pattern(pattern, children, outer_scope));
+                        inner_scope.insert(
+                            decl.key.clone(),
+                            self.fill_pattern(pattern, children, outer_scope),
+                        );
                     }
                     &None => {
                         inner_scope.remove(&decl.key);

--- a/src/core/parse/earley.rs
+++ b/src/core/parse/earley.rs
@@ -15,7 +15,11 @@ use {
 pub struct EarleyParser;
 
 impl Parser for EarleyParser {
-    fn parse(&self, scan: Vec<Token<String>>, grammar: &Grammar) -> Result<Tree, parse::Error> {
+    fn parse(
+        &self,
+        scan: Vec<Token<String>>,
+        grammar: &Grammar,
+    ) -> Result<Tree, parse::Error> {
         let mut chart: RChart = RChart::new();
         let mut parse_chart: PChart = PChart::new();
 
@@ -222,7 +226,11 @@ impl Parser for EarleyParser {
                 Ok(parse_tree(grammar, &scan, parse_chart))
             } else {
                 Err(parse::Error {
-                    message: format!("Largest parse did not consume all tokens: {} of {}", cursor - 1, scan.len()),
+                    message: format!(
+                        "Largest parse did not consume all tokens: {} of {}",
+                        cursor - 1,
+                        scan.len()
+                    ),
                 })
             }
         } else {
@@ -236,7 +244,11 @@ impl Parser for EarleyParser {
                 })
             } else {
                 Err(parse::Error {
-                    message: format!("Recognition failed at token {}: {}", cursor, scan[cursor - 1].to_string()),
+                    message: format!(
+                        "Recognition failed at token {}: {}",
+                        cursor,
+                        scan[cursor - 1].to_string()
+                    ),
                 })
             }
         };
@@ -266,7 +278,13 @@ impl Parser for EarleyParser {
                         children: {
                             let mut children: Vec<Tree> =
                                 top_list(start, edge, grammar, scan, chart).iter().rev()
-                                    .map(|&(node, ref edge)| recur(node, &edge, grammar, scan, chart))
+                                    .map(|&(node, ref edge)| recur(
+                                        node,
+                                        &edge,
+                                        grammar,
+                                        scan,
+                                        chart,
+                                    ))
                                     .collect();
                             if children.is_empty() { //Empty rhs
                                 children.push(Tree::null());

--- a/src/core/parse/earley.rs
+++ b/src/core/parse/earley.rs
@@ -76,13 +76,9 @@ impl Parser for EarleyParser {
             let mut i = 0;
             while i < chart.row(cursor).incomplete().len() {
                 let item = chart.row(cursor).incomplete().item(i).clone();
-                let next = (&item).next_symbol();
-                match next {
-                    None => {}
-                    Some(symbol) => {
-                        if !grammar.is_terminal(symbol) {
-                            predict_op(&item, cursor, symbol, grammar, chart);
-                        }
+                if let Some(symbol) = (&item).next_symbol() {
+                    if !grammar.is_terminal(symbol) {
+                        predict_op(&item, cursor, symbol, grammar, chart);
                     }
                 }
                 i += 1;
@@ -175,28 +171,25 @@ impl Parser for EarleyParser {
             let mut dest: Vec<Item> = Vec::new();
 
             for item in src {
-                match item.next_symbol() {
-                    None => {}
-                    Some(sym) => {
-                        if sym == symbol {
-                            let mut last_item = item.clone();
+                if let Some(sym) = item.next_symbol() {
+                    if sym == symbol {
+                        let mut last_item = item.clone();
 
-                            loop {
-                                last_item = Item {
-                                    rule: last_item.rule,
-                                    start: last_item.start,
-                                    next: last_item.next + 1,
-                                };
+                        loop {
+                            last_item = Item {
+                                rule: last_item.rule,
+                                start: last_item.start,
+                                next: last_item.next + 1,
+                            };
 
-                                dest.push(last_item.clone());
+                            dest.push(last_item.clone());
 
-                                match last_item.next_symbol() {
-                                    None => break,
-                                    Some(sym) => {
-                                        let sym_string = sym.to_string();
-                                        if !grammar.is_nullable_nt(&sym_string) {
-                                            break;
-                                        }
+                            match last_item.next_symbol() {
+                                None => break,
+                                Some(sym) => {
+                                    let sym_string = sym.to_string();
+                                    if !grammar.is_nullable_nt(&sym_string) {
+                                        break;
                                     }
                                 }
                             }
@@ -334,12 +327,9 @@ impl Parser for EarleyParser {
                     Some(Vec::new())
                 } else {
                     for edge in edges(depth, root) {
-                        match df_search(edges, leaf, depth + 1, edge.finish) {
-                            None => {}
-                            Some(mut path) => {
-                                path.push((root, edge));
-                                return Some(path);
-                            }
+                        if let Some(mut path) = df_search(edges, leaf, depth + 1, edge.finish) {
+                            path.push((root, edge));
+                            return Some(path);
                         }
                     }
                     None

--- a/src/core/parse/grammar.rs
+++ b/src/core/parse/grammar.rs
@@ -146,17 +146,12 @@ impl GrammarBuilder {
         loop {
             match work_stack.pop() {
                 None => break,
-                Some(work_symbol) => {
-                    match prods_by_rhs.get(work_symbol) {
-                        None => {}
-                        Some(prods) => {
-                            for prod in prods {
-                                if !nss.contains(&prod.lhs)
-                                    && prod.rhs.iter().all(|sym| nss.contains(sym)) {
-                                    nss.insert(prod.lhs.clone());
-                                    work_stack.push(&prod.lhs);
-                                }
-                            }
+                Some(work_symbol) => if let Some(prods) = prods_by_rhs.get(work_symbol) {
+                    for prod in prods {
+                        if !nss.contains(&prod.lhs)
+                            && prod.rhs.iter().all(|sym| nss.contains(sym)) {
+                            nss.insert(prod.lhs.clone());
+                            work_stack.push(&prod.lhs);
                         }
                     }
                 }

--- a/src/core/parse/mod.rs
+++ b/src/core/parse/mod.rs
@@ -53,20 +53,22 @@ impl Tree {
 
     fn to_string_internal(&self, prefix: String, is_tail: bool) -> String {
         if self.children.len() == 0 {
-            format!("{}{}{}", prefix, if is_tail { "└── " } else { "├── " }, self.lhs.to_string())
+            format!(
+                "{}{}{}", prefix, if is_tail { "└── " } else { "├── " }, self.lhs.to_string()
+            )
         } else {
-            let mut s = format!("{}{}{}", prefix, if is_tail { "└── " } else { "├── " }, self.lhs.kind);
+            let mut builder = format!(
+                "{}{}{}", prefix, if is_tail { "└── " } else { "├── " }, self.lhs.kind
+            );
             let mut i = 0;
             let len = self.children.len();
             for child in &self.children {
-                if i == len - 1 {
-                    s = format!("{}\n{}", s, child.to_string_internal(format!("{}{}", prefix, if is_tail { "    " } else { "│   " }), true));
-                } else {
-                    s = format!("{}\n{}", s, child.to_string_internal(format!("{}{}", prefix, if is_tail { "    " } else { "│   " }), false));
-                }
+                let margin = format!("{}{}", prefix, if is_tail { "    " } else { "│   " });
+                let child_string = child.to_string_internal(margin, i == len - 1);
+                builder = format!("{}\n{}", builder, child_string);
                 i += 1;
             }
-            s
+            builder
         }
     }
 

--- a/src/core/scan/compile/maximal_munch.rs
+++ b/src/core/scan/compile/maximal_munch.rs
@@ -28,7 +28,7 @@ impl<State: PartialEq + Clone> Scanner<State> for MaximalMunchScanner {
             let mut line: usize = line;
             let mut character: usize = character;
 
-            let mut last_accepting: (usize, State, usize, usize) = (scanned, state.clone(), line, character);
+            let mut last_accepting = (scanned, state.clone(), line, character);
 
             while !input.is_empty() && dfa.has_transition(input[0], &state) {
                 let head: char = input[0];
@@ -62,7 +62,13 @@ impl<State: PartialEq + Clone> Scanner<State> for MaximalMunchScanner {
         let mut character: usize = 1;
 
         while !input.is_empty() {
-            let (scanned, end_state, end_line, end_character) = scan_one(input, line, character, dfa);
+            //TODO replace this tuple with a return object
+            let (scanned, end_state, end_line, end_character) = scan_one(
+                input,
+                line,
+                character,
+                dfa,
+            );
 
             line = end_line;
             character = end_character;

--- a/src/core/scan/compile/mod.rs
+++ b/src/core/scan/compile/mod.rs
@@ -3,7 +3,7 @@ use core::scan::{Error, Kind, Token};
 mod maximal_munch;
 
 pub trait Scanner<State: PartialEq + Clone>: 'static + Send + Sync {
-    fn scan<'a, 'b>(&self, input: &'a str, dfa: &'b DFA<State>) -> Result<Vec<Token<String>>, Error>;
+    fn scan(&self, input: &str, dfa: &DFA<State>) -> Result<Vec<Token<String>>, Error>;
 }
 
 pub fn def_scanner<State: PartialEq + Clone>() -> Box<Scanner<State>> {
@@ -47,7 +47,7 @@ pub struct CompileTransitionDelta<State> {
 }
 
 impl<State: PartialEq + Clone> TransitionDelta<State> for CompileTransitionDelta<State> {
-    fn transition<'a>(&'a self, state: &State, c: char) -> State {
+    fn transition(&self, state: &State, c: char) -> State {
         (self.delta)(state.clone(), c)
     }
 
@@ -66,7 +66,11 @@ impl<State: PartialEq + Clone> TransitionDelta<State> for CompileTransitionDelta
 }
 
 impl<State: PartialEq + Clone> CompileTransitionDelta<State> {
-    pub fn build<'a>(delta: fn(State, char) -> State, tokenizer: fn(State) -> String, fail_state: State) -> CompileTransitionDelta<State> {
+    pub fn build<'a>(
+        delta: fn(State, char) -> State,
+        tokenizer: fn(State) -> String,
+        fail_state: State,
+    ) -> CompileTransitionDelta<State> {
         CompileTransitionDelta {
             delta,
             tokenizer,

--- a/src/core/scan/mod.rs
+++ b/src/core/scan/mod.rs
@@ -16,7 +16,11 @@ pub struct Token<Kind: fmt::Debug> {
 
 impl<Kind: Data> Data for Token<Kind> {
     fn to_string(&self) -> String {
-        format!("{} <- '{}'", self.kind.to_string(), self.lexeme.replace('\n', "\\n").replace('\t', "\\t"))
+        format!(
+            "{} <- '{}'",
+            self.kind.to_string(),
+            self.lexeme.replace('\n', "\\n").replace('\t', "\\t")
+        )
     }
 }
 
@@ -29,7 +33,13 @@ pub struct Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "No accepting scans after ({},{}): {}...", self.line, self.character, self.sequence)
+        write!(
+            f,
+            "No accepting scans after ({},{}): {}...",
+            self.line,
+            self.character,
+            self.sequence
+        )
     }
 }
 

--- a/src/core/scan/runtime/ecdfa.rs
+++ b/src/core/scan/runtime/ecdfa.rs
@@ -94,7 +94,12 @@ impl CDFABuilder<String, String, EncodedCDFA> for EncodedCDFABuilder {
         self
     }
 
-    fn mark_trans(&mut self, from: &String, to: &String, on: char) -> Result<&mut Self, CDFAError> {
+    fn mark_trans(
+        &mut self,
+        from: &String,
+        to: &String,
+        on: char,
+    ) -> Result<&mut Self, CDFAError> {
         let from_encoded = self.encode(from);
         let to_encoded = self.encode(to);
 
@@ -279,7 +284,9 @@ impl TransitionTrie {
             };
             node.add_child(c, child);
         } else if last {
-            return Err(CDFAError::BuildErr(format!("Transition trie is not prefix free on character '{}'", c)));
+            return Err(CDFAError::BuildErr(format!(
+                "Transition trie is not prefix free on character '{}'", c
+            )));
         }
         Ok(())
     }

--- a/src/core/scan/runtime/maximal_munch.rs
+++ b/src/core/scan/runtime/maximal_munch.rs
@@ -124,17 +124,14 @@ impl<State: Data, Kind: Data> Scanner<State, Kind> for MaximalMunchScanner {
                         break;
                     }
                 }
-                Some(state) => match cdfa.tokenize(&state) {
-                    None => {}
-                    Some(kind) => {
-                        let token = Token {
-                            kind,
-                            lexeme: result.scanned,
-                        };
+                Some(state) => if let Some(kind) = cdfa.tokenize(&state) {
+                    let token = Token {
+                        kind,
+                        lexeme: result.scanned,
+                    };
 
-                        //TODO write tokens to another ReadDrivenStream
-                        tokens.push(token);
-                    }
+                    //TODO write tokens to another ReadDrivenStream
+                    tokens.push(token);
                 }
             }
         }

--- a/src/core/spec.rs
+++ b/src/core/spec.rs
@@ -998,8 +998,7 @@ id ^ID
 
 s -> ;";
 
-        let input = "fdkgdfjgdjglkdjglkdjgljbnhbduhoifjeoigjeoghknhkjdfjgoirjt for if endif \
-        elseif somethign eldsfnj hi bob joe here final for fob else if id idhere fobre f ".to_string();
+        let input = "fdkgdfjgdjglkdjglkdjgljbnhbduhoifjeoigjeoghknhkjdfjgoirjt for if endif elseif somethign eldsfnj hi bob joe here final for fob else if id idhere fobre f ".to_string();
         let mut iter = input.chars();
         let mut getter = || {
             iter.next()

--- a/src/core/util/thread_pool.rs
+++ b/src/core/util/thread_pool.rs
@@ -405,7 +405,10 @@ mod tests {
 
         //verify
         let err = result.err().unwrap();
-        assert_eq!(format!("{}", err), "Error enqueuing worker job: sending on a closed channel");
+        assert_eq!(
+            format!("{}", err),
+            "Error enqueuing worker job: sending on a closed channel"
+        );
 
         assert!(err.cause().is_none());
     }
@@ -422,7 +425,10 @@ mod tests {
 
         //verify
         let err = result.err().unwrap();
-        assert_eq!(format!("{}", err), "Error enqueuing worker termination signal: sending on a closed channel");
+        assert_eq!(
+            format!("{}", err),
+            "Error enqueuing worker termination signal: sending on a closed channel"
+        );
 
         assert!(err.cause().is_none());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,8 +64,12 @@ pub enum BuildError {
 impl fmt::Display for BuildError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            BuildError::SpecParseErr(ref err) => write!(f, "Failed to parse specification: {}", err),
-            BuildError::SpecGenErr(ref err) => write!(f, "Failed to generate specification: {}", err),
+            BuildError::SpecParseErr(ref err) => write!(
+                f, "Failed to parse specification: {}", err
+            ),
+            BuildError::SpecGenErr(ref err) => write!(
+                f, "Failed to generate specification: {}", err
+            ),
         }
     }
 }


### PR DESCRIPTION
- Replace one-sided matchers with if-let statements.
- Break macros (except `panic!(...)`) onto multiple lines.