### PR TITLE
Context-sensitive CDFA

### DIFF
--- a/src/core/fmt/pattern.rs
+++ b/src/core/fmt/pattern.rs
@@ -65,7 +65,7 @@ fn build_pattern_ecdfa() -> Result<EncodedCDFA<String>, scan::CDFAError> {
         .mark_trans(&S::ZERO, '0')?
         .mark_range(&S::NUM, '1', '9')?
         .mark_range(&S::ALPHA, 'a', 'Z')?
-        .mark_def(&S::FILLER)?;
+        .default_to(&S::FILLER)?;
 
     builder.state(&S::FILLER)
         .mark_trans(&S::ESC, '\\')?
@@ -74,27 +74,27 @@ fn build_pattern_ecdfa() -> Result<EncodedCDFA<String>, scan::CDFAError> {
         .mark_trans(&S::FAIL, '[')?
         .mark_trans(&S::FAIL, ';')?
         .mark_trans(&S::FAIL, '=')?
-        .mark_def(&S::FILLER)?
-        .mark_token(&"FILLER".to_string());
+        .default_to(&S::FILLER)?
+        .tokenize(&"FILLER".to_string());
 
-    builder.mark_def(&S::ESC, &S::FILLER)?;
+    builder.default_to(&S::ESC, &S::FILLER)?;
 
     builder.state(&S::NUM)
         .mark_range(&S::NUM, '0', '9')?
-        .mark_token(&"NUM".to_string());
+        .tokenize(&"NUM".to_string());
 
     builder.state(&S::ALPHA)
         .mark_range(&S::ALPHA, 'a', 'Z')?
-        .mark_token(&"ALPHA".to_string());
+        .tokenize(&"ALPHA".to_string());
 
     builder
-        .mark_token(&S::SEMI, &"SEMI".to_string())
-        .mark_token(&S::EQ, &"EQ".to_string())
-        .mark_token(&S::LBRACE, &"LBRACE".to_string())
-        .mark_token(&S::RBRACE, &"RBRACE".to_string())
-        .mark_token(&S::LBRACKET, &"LBRACKET".to_string())
-        .mark_token(&S::RBRACKET, &"RBRACKET".to_string())
-        .mark_token(&S::ZERO, &"NUM".to_string());
+        .tokenize(&S::SEMI, &"SEMI".to_string())
+        .tokenize(&S::EQ, &"EQ".to_string())
+        .tokenize(&S::LBRACE, &"LBRACE".to_string())
+        .tokenize(&S::RBRACE, &"RBRACE".to_string())
+        .tokenize(&S::LBRACKET, &"LBRACKET".to_string())
+        .tokenize(&S::RBRACKET, &"RBRACKET".to_string())
+        .tokenize(&S::ZERO, &"NUM".to_string());
 
     builder.build()
 }

--- a/src/core/fmt/pattern.rs
+++ b/src/core/fmt/pattern.rs
@@ -23,7 +23,7 @@ use {
 static PATTERN_ALPHABET: &'static str =
     "{}[];=0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ \n\t`~!@#$%^&*()_-+:'\"<>,.?/\\|";
 
-#[derive(PartialEq, Eq, Hash, Clone)]
+#[derive(PartialEq, Eq, Hash, Clone, Debug)]
 enum S {
     START,
     LBRACE,
@@ -75,17 +75,29 @@ fn build_pattern_ecdfa() -> Result<EncodedCDFA<String>, scan::CDFAError> {
         .mark_trans(&S::FAIL, ';')?
         .mark_trans(&S::FAIL, '=')?
         .default_to(&S::FILLER)?
+        .accept()
         .tokenize(&"FILLER".to_string());
 
     builder.default_to(&S::ESC, &S::FILLER)?;
 
     builder.state(&S::NUM)
         .mark_range(&S::NUM, '0', '9')?
+        .accept()
         .tokenize(&"NUM".to_string());
 
     builder.state(&S::ALPHA)
         .mark_range(&S::ALPHA, 'a', 'Z')?
+        .accept()
         .tokenize(&"ALPHA".to_string());
+
+    builder
+        .accept(&S::SEMI)
+        .accept(&S::EQ)
+        .accept(&S::LBRACE)
+        .accept(&S::RBRACE)
+        .accept(&S::LBRACKET)
+        .accept(&S::RBRACKET)
+        .accept(&S::ZERO);
 
     builder
         .tokenize(&S::SEMI, &"SEMI".to_string())

--- a/src/core/scan/ecdfa.rs
+++ b/src/core/scan/ecdfa.rs
@@ -12,7 +12,7 @@ use {
         },
     },
     std::{
-        collections::{HashMap, HashSet},
+        collections::HashMap,
         hash::Hash,
         usize,
     },
@@ -24,7 +24,7 @@ pub struct EncodedCDFABuilder<State: Eq + Hash + Clone, Kind: Default + Clone> {
     alphabet_str: String,
 
     alphabet: HashedAlphabet,
-    accepting: HashSet<usize>,
+    accepting: HashMap<usize, Option<usize>>,
     t_delta: CEHashMap<TransitionTrie>,
     tokenizer: CEHashMap<Kind>,
     start: usize,
@@ -86,7 +86,7 @@ for EncodedCDFABuilder<State, Kind> {
             alphabet_str: String::new(),
 
             alphabet: HashedAlphabet::new(),
-            accepting: HashSet::new(),
+            accepting: HashMap::new(),
             t_delta: CEHashMap::new(),
             tokenizer: CEHashMap::new(),
             start: usize::max_value(),
@@ -117,9 +117,16 @@ for EncodedCDFABuilder<State, Kind> {
         self
     }
 
-    fn mark_accepting(&mut self, state: &State) -> &mut Self {
+    fn accept(&mut self, state: &State) -> &mut Self {
         let state_encoded = self.encode(state);
-        self.accepting.insert(state_encoded);
+        self.accepting.insert(state_encoded, None);
+        self
+    }
+
+    fn accept_to(&mut self, state: &State, to: &State) -> &mut Self {
+        let state_encoded = self.encode(state);
+        let to_encoded = self.encode(to);
+        self.accepting.insert(state_encoded, Some(to_encoded));
         self
     }
 
@@ -199,7 +206,7 @@ for EncodedCDFABuilder<State, Kind> {
         Ok(self)
     }
 
-    fn mark_def(&mut self, from: &State, to: &State) -> Result<&mut Self, CDFAError> {
+    fn default_to(&mut self, from: &State, to: &State) -> Result<&mut Self, CDFAError> {
         let from_encoded = self.encode(from);
         let to_encoded = self.encode(to);
 
@@ -213,8 +220,8 @@ for EncodedCDFABuilder<State, Kind> {
         }
     }
 
-    fn mark_token(&mut self, state: &State, token: &Kind) -> &mut Self {
-        self.mark_accepting(state);
+    fn tokenize(&mut self, state: &State, token: &Kind) -> &mut Self {
+        self.accept(state);
         let state_encoded = self.encode(state);
         self.tokenizer.insert(state_encoded, token.clone());
         self
@@ -233,8 +240,13 @@ pub struct EncodedCDFAStateBuilder<
 
 impl<'scope, 'state: 'scope, State: 'state + Eq + Hash + Clone, Kind: 'scope + Default + Clone>
 EncodedCDFAStateBuilder<'scope, 'state, State, Kind> {
-    pub fn mark_accepting(&mut self) -> &mut Self {
-        self.ecdfa_builder.mark_accepting(self.state);
+    pub fn accept(&mut self) -> &mut Self {
+        self.ecdfa_builder.accept(self.state);
+        self
+    }
+
+    pub fn accept_to(&mut self, to: &State) -> &mut Self {
+        self.ecdfa_builder.accept_to(self.state, to);
         self
     }
 
@@ -266,13 +278,13 @@ EncodedCDFAStateBuilder<'scope, 'state, State, Kind> {
         Ok(self)
     }
 
-    pub fn mark_def(&mut self, to: &State) -> Result<&mut Self, CDFAError> {
-        self.ecdfa_builder.mark_def(self.state, to)?;
+    pub fn default_to(&mut self, to: &State) -> Result<&mut Self, CDFAError> {
+        self.ecdfa_builder.default_to(self.state, to)?;
         Ok(self)
     }
 
-    pub fn mark_token(&mut self, token: &Kind) -> &mut Self {
-        self.ecdfa_builder.mark_token(self.state, token);
+    pub fn tokenize(&mut self, token: &Kind) -> &mut Self {
+        self.ecdfa_builder.tokenize(self.state, token);
         self
     }
 }
@@ -281,7 +293,7 @@ pub struct EncodedCDFA<Kind: Default + Clone> {
     //TODO add separate error message if character not in alphabet
     #[allow(dead_code)]
     alphabet: HashedAlphabet,
-    accepting: HashSet<usize>,
+    accepting: HashMap<usize, Option<usize>>,
     t_delta: CEHashMap<TransitionTrie>,
     tokenizer: CEHashMap<Kind>,
     start: usize,
@@ -309,7 +321,14 @@ impl<Kind: Default + Clone> CDFA<usize, Kind> for EncodedCDFA<Kind> {
     }
 
     fn accepts(&self, state: &usize) -> bool {
-        self.accepting.contains(state)
+        self.accepting.contains_key(state)
+    }
+
+    fn accepts_to(&self, state: &usize) -> Option<usize> {
+        match self.accepting.get(state) {
+            None => None,
+            Some(state_opt) => state_opt.clone()
+        }
     }
 
     fn tokenize(&self, state: &usize) -> Option<Kind> {
@@ -485,10 +504,10 @@ mod tests {
             .mark_trans(&"zero".to_string(), '0').unwrap()
             .mark_trans(&"notzero".to_string(), '1').unwrap();
         builder.state(&"notzero".to_string())
-            .mark_def(&"notzero".to_string()).unwrap()
-            .mark_token(&"NZ".to_string());
+            .default_to(&"notzero".to_string()).unwrap()
+            .tokenize(&"NZ".to_string());
         builder
-            .mark_token(&"zero".to_string(), &"ZERO".to_string());
+            .tokenize(&"zero".to_string(), &"ZERO".to_string());
 
         let cdfa: EncodedCDFA<String> = builder.build().unwrap();
 
@@ -531,10 +550,10 @@ NZ <- '11010101'
             .mark_trans(&"ws".to_string(), ' ').unwrap()
             .mark_trans(&"ws".to_string(), '\t').unwrap()
             .mark_trans(&"ws".to_string(), '\n').unwrap()
-            .mark_token(&"WS".to_string());
+            .tokenize(&"WS".to_string());
         builder
-            .mark_token(&"lbr".to_string(), &"LBR".to_string())
-            .mark_token(&"rbr".to_string(), &"RBR".to_string());
+            .tokenize(&"lbr".to_string(), &"LBR".to_string())
+            .tokenize(&"rbr".to_string(), &"RBR".to_string());
 
         let cdfa: EncodedCDFA<String> = builder.build().unwrap();
 
@@ -588,10 +607,10 @@ RBR <- '}'
             .mark_trans(&"ws".to_string(), ' ').unwrap()
             .mark_trans(&"ws".to_string(), '\t').unwrap()
             .mark_trans(&"ws".to_string(), '\n').unwrap()
-            .mark_accepting();
+            .accept();
         builder
-            .mark_token(&"lbr".to_string(), &"LBR".to_string())
-            .mark_token(&"rbr".to_string(), &"RBR".to_string());
+            .tokenize(&"lbr".to_string(), &"LBR".to_string())
+            .tokenize(&"rbr".to_string(), &"RBR".to_string());
 
         let cdfa: EncodedCDFA<String> = builder.build().unwrap();
 
@@ -641,10 +660,10 @@ RBR <- '}'
             .mark_trans(&"ws".to_string(), ' ').unwrap()
             .mark_trans(&"ws".to_string(), '\t').unwrap()
             .mark_trans(&"ws".to_string(), '\n').unwrap()
-            .mark_accepting();
+            .accept();
         builder
-            .mark_token(&"lbr".to_string(), &"LBR".to_string())
-            .mark_token(&"rbr".to_string(), &"RBR".to_string());
+            .tokenize(&"lbr".to_string(), &"LBR".to_string())
+            .tokenize(&"rbr".to_string(), &"RBR".to_string());
 
         let cdfa: EncodedCDFA<String> = builder.build().unwrap();
 
@@ -685,10 +704,10 @@ RBR <- '}'
             .mark_trans(&"ws".to_string(), ' ').unwrap()
             .mark_trans(&"ws".to_string(), '\t').unwrap()
             .mark_trans(&"ws".to_string(), '\n').unwrap()
-            .mark_accepting();
+            .accept();
         builder
-            .mark_token(&"lbr".to_string(), &"LBR".to_string())
-            .mark_token(&"rbr".to_string(), &"RBR".to_string());
+            .tokenize(&"lbr".to_string(), &"LBR".to_string())
+            .tokenize(&"rbr".to_string(), &"RBR".to_string());
 
         let cdfa: EncodedCDFA<String> = builder.build().unwrap();
 
@@ -723,8 +742,8 @@ RBR <- '}'
             .mark_chain(&"four".to_string(), "four".chars()).unwrap()
             .mark_chain(&"five".to_string(), "five".chars()).unwrap();
         builder
-            .mark_token(&"four".to_string(), &"FOUR".to_string())
-            .mark_token(&"five".to_string(), &"FIVE".to_string());
+            .tokenize(&"four".to_string(), &"FOUR".to_string())
+            .tokenize(&"five".to_string(), &"FIVE".to_string());
 
         let cdfa: EncodedCDFA<String> = builder.build().unwrap();
 
@@ -762,12 +781,12 @@ FIVE <- 'five'
             .mark_start(&"start".to_string());
         builder.state(&"start".to_string())
             .mark_chain(&"FOR".to_string(), "for".chars()).unwrap()
-            .mark_def(&"id".to_string()).unwrap();
+            .default_to(&"id".to_string()).unwrap();
         builder
-            .mark_token(&"FOR".to_string(), &"FOR".to_string())
-            .mark_token(&"id".to_string(), &"ID".to_string());
+            .tokenize(&"FOR".to_string(), &"FOR".to_string())
+            .tokenize(&"id".to_string(), &"ID".to_string());
         builder
-            .mark_def(&"id".to_string(), &"id".to_string()).unwrap();
+            .default_to(&"id".to_string(), &"id".to_string()).unwrap();
 
         let cdfa: EncodedCDFA<String> = builder.build().unwrap();
 
@@ -786,6 +805,73 @@ FIVE <- 'five'
         //verify
         assert_eq!(tokens_string(&tokens), "\
 ID <- 'fdk'
+");
+    }
+
+    #[test]
+    fn scan_context_sensitive() {
+        //setup
+        #[derive(PartialEq, Eq, Hash, Clone)]
+        enum S {
+            Start,
+            A,
+            BangIn,
+            BangOut,
+            Hidden,
+            Num,
+        }
+
+        let mut builder: EncodedCDFABuilder<S, String> = EncodedCDFABuilder::new();
+        builder
+            .set_alphabet("a!123456789".chars())
+            .mark_start(&S::Start);
+        builder.state(&S::Start)
+            .mark_trans(&S::A, 'a').unwrap()
+            .mark_trans(&S::BangIn, '!').unwrap();
+        builder.state(&S::A)
+            .mark_trans(&S::A, 'a').unwrap()
+            .tokenize(&"A".to_string());
+        builder.state(&S::BangIn)
+            .tokenize(&"BANG".to_string())
+            .accept_to(&S::Hidden);
+        builder.state(&S::BangOut)
+            .tokenize(&"BANG".to_string())
+            .accept_to(&S::Start);
+        builder.state(&S::Hidden)
+            .mark_range(&S::Num, '1', '9').unwrap()
+            .mark_trans(&S::BangOut, '!').unwrap();
+        builder.state(&S::Num)
+            .tokenize(&"NUM".to_string())
+            .accept_to(&S::Hidden);
+
+        let cdfa: EncodedCDFA<String> = builder.build().unwrap();
+
+        let input = "!!aaa!!a!49913!a".to_string();
+        let mut iter = input.chars();
+        let mut getter = || iter.next();
+        let mut stream: StreamSource<char> = StreamSource::observe(&mut getter);
+
+        let scanner = scan::def_scanner();
+
+        //exercise
+        let tokens = scanner.scan(&mut stream, &cdfa).unwrap();
+
+        //verify
+        assert_eq!(tokens_string(&tokens), "\
+BANG <- '!'
+BANG <- '!'
+A <- 'aaa'
+BANG <- '!'
+BANG <- '!'
+A <- 'a'
+BANG <- '!'
+NUM <- '4'
+NUM <- '9'
+NUM <- '9'
+NUM <- '1'
+NUM <- '3'
+BANG <- '!'
+A <- 'a'
 ");
     }
 

--- a/src/core/scan/ecdfa.rs
+++ b/src/core/scan/ecdfa.rs
@@ -549,7 +549,7 @@ impl AcceptorDestinationMux {
     ) -> Result<(), CDFAError> {
         if self.all.is_some() {
             return Err(CDFAError::BuildErr(format!(
-                "State '{:?}' already has an acceptance destination from all incoming states", state
+                "State {:?} already has an acceptance destination from all incoming states", state
             )));
         }
 
@@ -562,7 +562,7 @@ impl AcceptorDestinationMux {
                 let entry = mux.get(&from_encoded);
                 if entry.is_some() && *entry.unwrap() != dest_encoded {
                     return Err(CDFAError::BuildErr(format!(
-                        "State '{:?}' is accepted multiple times with different destinations", state
+                        "State {:?} is accepted multiple times with different destinations", state
                     )));
                 }
             }
@@ -580,19 +580,11 @@ impl AcceptorDestinationMux {
     ) -> Result<(), CDFAError> {
         if self.mux.is_some() {
             return Err(CDFAError::BuildErr(format!(
-                "State '{:?}' already has an acceptance destination from a specific state", state
+                "State {:?} already has an acceptance destination from a specific state", state
             )));
         }
 
-        if self.all.is_some() {
-            if self.all.unwrap() != dest_encoded {
-                return Err(CDFAError::BuildErr(format!(
-                    "State '{:?}' is accepted multiple times with different destinations", state
-                )));
-            }
-        } else {
-            self.all = Some(dest_encoded)
-        }
+        self.all = Some(dest_encoded);
 
         Ok(())
     }

--- a/src/core/scan/ecdfa.rs
+++ b/src/core/scan/ecdfa.rs
@@ -13,24 +13,25 @@ use {
     },
     std::{
         collections::HashMap,
+        fmt::Debug,
         hash::Hash,
         usize,
     },
 };
 
-pub struct EncodedCDFABuilder<State: Eq + Hash + Clone, Kind: Default + Clone> {
+pub struct EncodedCDFABuilder<State: Eq + Hash + Clone + Debug, Kind: Default + Clone> {
     encoder: HashMap<State, usize>,
     decoder: Vec<State>,
     alphabet_str: String,
 
     alphabet: HashedAlphabet,
-    accepting: HashMap<usize, Option<usize>>,
+    accepting: HashMap<usize, AcceptorDestinationMux>,
     t_delta: CEHashMap<TransitionTrie>,
     tokenizer: CEHashMap<Kind>,
     start: usize,
 }
 
-impl<State: Eq + Hash + Clone, Kind: Default + Clone> EncodedCDFABuilder<State, Kind> {
+impl<State: Eq + Hash + Clone + Debug, Kind: Default + Clone> EncodedCDFABuilder<State, Kind> {
     fn encode(&mut self, val: &State) -> usize {
         if self.encoder.contains_key(val) {
             *self.encoder.get(val).unwrap()
@@ -77,8 +78,8 @@ impl<State: Eq + Hash + Clone, Kind: Default + Clone> EncodedCDFABuilder<State, 
     }
 }
 
-impl<State: Eq + Hash + Clone, Kind: Default + Clone> CDFABuilder<State, Kind, EncodedCDFA<Kind>>
-for EncodedCDFABuilder<State, Kind> {
+impl<State: Eq + Hash + Clone + Debug, Kind: Default + Clone>
+CDFABuilder<State, Kind, EncodedCDFA<Kind>> for EncodedCDFABuilder<State, Kind> {
     fn new() -> Self {
         EncodedCDFABuilder {
             encoder: HashMap::new(),
@@ -119,15 +120,53 @@ for EncodedCDFABuilder<State, Kind> {
 
     fn accept(&mut self, state: &State) -> &mut Self {
         let state_encoded = self.encode(state);
-        self.accepting.insert(state_encoded, None);
+
+        if self.accepting.contains_key(&state_encoded) {
+            return self;
+        }
+
+        self.accepting.insert(state_encoded, AcceptorDestinationMux::new());
         self
     }
 
-    fn accept_to(&mut self, state: &State, to: &State) -> &mut Self {
+    fn accept_to(
+        &mut self,
+        state: &State,
+        from: &State,
+        to: &State,
+    ) -> Result<&mut Self, CDFAError> {
+        let state_encoded = self.encode(state);
+        let from_encoded = self.encode(from);
+        let to_encoded = self.encode(to);
+
+        if !self.accepting.contains_key(&state_encoded) {
+            let mut accd_mux = AcceptorDestinationMux::new();
+            accd_mux.add_from(state, to_encoded, from_encoded)?;
+            self.accepting.insert(state_encoded, accd_mux);
+        } else if let Some(ref mut accd_mux) = self.accepting.get_mut(&state_encoded) {
+            accd_mux.add_from(state, to_encoded, from_encoded)?;
+        }
+
+        Ok(self)
+    }
+
+    fn accept_to_from_all(
+        &mut self,
+        state: &State,
+        to: &State,
+    ) -> Result<&mut Self, CDFAError> {
         let state_encoded = self.encode(state);
         let to_encoded = self.encode(to);
-        self.accepting.insert(state_encoded, Some(to_encoded));
-        self
+
+        if !self.accepting.contains_key(&state_encoded) {
+            let mut accd_mux = AcceptorDestinationMux::new();
+            accd_mux.add_from_all(state, to_encoded)?;
+            self.accepting.insert(state_encoded, accd_mux);
+        } else if let Some(ref mut accd_mux) = self.accepting.get_mut(&state_encoded) {
+            accd_mux.add_from_all(state, to_encoded)?;
+        }
+
+        Ok(self)
     }
 
     fn mark_start(&mut self, state: &State) -> &mut Self {
@@ -221,7 +260,6 @@ for EncodedCDFABuilder<State, Kind> {
     }
 
     fn tokenize(&mut self, state: &State, token: &Kind) -> &mut Self {
-        self.accept(state);
         let state_encoded = self.encode(state);
         self.tokenizer.insert(state_encoded, token.clone());
         self
@@ -231,23 +269,27 @@ for EncodedCDFABuilder<State, Kind> {
 pub struct EncodedCDFAStateBuilder<
     'scope,
     'state: 'scope,
-    State: 'state + Eq + Hash + Clone,
+    State: 'state + Eq + Hash + Clone + Debug,
     Kind: 'scope + Default + Clone
 > {
     ecdfa_builder: &'scope mut EncodedCDFABuilder<State, Kind>,
     state: &'state State,
 }
 
-impl<'scope, 'state: 'scope, State: 'state + Eq + Hash + Clone, Kind: 'scope + Default + Clone>
-EncodedCDFAStateBuilder<'scope, 'state, State, Kind> {
+impl<
+    'scope,
+    'state: 'scope,
+    State: 'state + Eq + Hash + Clone + Debug,
+    Kind: 'scope + Default + Clone
+> EncodedCDFAStateBuilder<'scope, 'state, State, Kind> {
     pub fn accept(&mut self) -> &mut Self {
         self.ecdfa_builder.accept(self.state);
         self
     }
 
-    pub fn accept_to(&mut self, to: &State) -> &mut Self {
-        self.ecdfa_builder.accept_to(self.state, to);
-        self
+    pub fn accept_to_from_all(&mut self, to: &State) -> Result<&mut Self, CDFAError> {
+        self.ecdfa_builder.accept_to_from_all(self.state, to)?;
+        Ok(self)
     }
 
     pub fn mark_trans(
@@ -293,7 +335,7 @@ pub struct EncodedCDFA<Kind: Default + Clone> {
     //TODO add separate error message if character not in alphabet
     #[allow(dead_code)]
     alphabet: HashedAlphabet,
-    accepting: HashMap<usize, Option<usize>>,
+    accepting: HashMap<usize, AcceptorDestinationMux>,
     t_delta: CEHashMap<TransitionTrie>,
     tokenizer: CEHashMap<Kind>,
     start: usize,
@@ -324,10 +366,15 @@ impl<Kind: Default + Clone> CDFA<usize, Kind> for EncodedCDFA<Kind> {
         self.accepting.contains_key(state)
     }
 
-    fn accepts_to(&self, state: &usize) -> Option<usize> {
+    fn acceptor_destination(&self, state: &usize, from: &usize) -> Option<usize> {
         match self.accepting.get(state) {
             None => None,
-            Some(state_opt) => state_opt.clone()
+            Some(accd_mux) => {
+                match accd_mux.get_destination(*from) {
+                    None => None,
+                    Some(destination) => Some(destination.clone())
+                }
+            }
         }
     }
 
@@ -481,6 +528,89 @@ impl TransitionNode {
     }
 }
 
+struct AcceptorDestinationMux {
+    mux: Option<HashMap<usize, usize>>,
+    all: Option<usize>,
+}
+
+impl AcceptorDestinationMux {
+    fn new() -> Self {
+        AcceptorDestinationMux {
+            mux: None,
+            all: None,
+        }
+    }
+
+    fn add_from<State: Debug>(
+        &mut self,
+        state: &State,
+        dest_encoded: usize,
+        from_encoded: usize,
+    ) -> Result<(), CDFAError> {
+        if self.all.is_some() {
+            return Err(CDFAError::BuildErr(format!(
+                "State '{:?}' already has an acceptance destination from all incoming states", state
+            )));
+        }
+
+        if !self.mux.is_some() {
+            let mut mux = HashMap::new();
+            mux.insert(from_encoded, dest_encoded);
+            self.mux = Some(mux);
+        } else if let Some(ref mut mux) = self.mux {
+            {
+                let entry = mux.get(&from_encoded);
+                if entry.is_some() && *entry.unwrap() != dest_encoded {
+                    return Err(CDFAError::BuildErr(format!(
+                        "State '{:?}' is accepted multiple times with different destinations", state
+                    )));
+                }
+            }
+
+            mux.insert(from_encoded, dest_encoded);
+        }
+
+        Ok(())
+    }
+
+    fn add_from_all<State: Debug>(
+        &mut self,
+        state: &State,
+        dest_encoded: usize,
+    ) -> Result<(), CDFAError> {
+        if self.mux.is_some() {
+            return Err(CDFAError::BuildErr(format!(
+                "State '{:?}' already has an acceptance destination from a specific state", state
+            )));
+        }
+
+        if self.all.is_some() {
+            if self.all.unwrap() != dest_encoded {
+                return Err(CDFAError::BuildErr(format!(
+                    "State '{:?}' is accepted multiple times with different destinations", state
+                )));
+            }
+        } else {
+            self.all = Some(dest_encoded)
+        }
+
+        Ok(())
+    }
+
+    fn get_destination(&self, from_encoded: usize) -> Option<usize> {
+        if let Some(dest) = self.all {
+            Some(dest)
+        } else if let Some(ref mux) = self.mux {
+            match mux.get(&from_encoded) {
+                None => None,
+                Some(dest) => Some(dest.clone())
+            }
+        } else {
+            None
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use core::{
@@ -505,8 +635,10 @@ mod tests {
             .mark_trans(&"notzero".to_string(), '1').unwrap();
         builder.state(&"notzero".to_string())
             .default_to(&"notzero".to_string()).unwrap()
+            .accept()
             .tokenize(&"NZ".to_string());
         builder
+            .accept(&"zero".to_string())
             .tokenize(&"zero".to_string(), &"ZERO".to_string());
 
         let cdfa: EncodedCDFA<String> = builder.build().unwrap();
@@ -550,9 +682,12 @@ NZ <- '11010101'
             .mark_trans(&"ws".to_string(), ' ').unwrap()
             .mark_trans(&"ws".to_string(), '\t').unwrap()
             .mark_trans(&"ws".to_string(), '\n').unwrap()
+            .accept()
             .tokenize(&"WS".to_string());
         builder
+            .accept(&"lbr".to_string())
             .tokenize(&"lbr".to_string(), &"LBR".to_string())
+            .accept(&"rbr".to_string())
             .tokenize(&"rbr".to_string(), &"RBR".to_string());
 
         let cdfa: EncodedCDFA<String> = builder.build().unwrap();
@@ -609,7 +744,9 @@ RBR <- '}'
             .mark_trans(&"ws".to_string(), '\n').unwrap()
             .accept();
         builder
+            .accept(&"lbr".to_string())
             .tokenize(&"lbr".to_string(), &"LBR".to_string())
+            .accept(&"rbr".to_string())
             .tokenize(&"rbr".to_string(), &"RBR".to_string());
 
         let cdfa: EncodedCDFA<String> = builder.build().unwrap();
@@ -662,7 +799,9 @@ RBR <- '}'
             .mark_trans(&"ws".to_string(), '\n').unwrap()
             .accept();
         builder
+            .accept(&"lbr".to_string())
             .tokenize(&"lbr".to_string(), &"LBR".to_string())
+            .accept(&"rbr".to_string())
             .tokenize(&"rbr".to_string(), &"RBR".to_string());
 
         let cdfa: EncodedCDFA<String> = builder.build().unwrap();
@@ -706,7 +845,9 @@ RBR <- '}'
             .mark_trans(&"ws".to_string(), '\n').unwrap()
             .accept();
         builder
+            .accept(&"lbr".to_string())
             .tokenize(&"lbr".to_string(), &"LBR".to_string())
+            .accept(&"rbr".to_string())
             .tokenize(&"rbr".to_string(), &"RBR".to_string());
 
         let cdfa: EncodedCDFA<String> = builder.build().unwrap();
@@ -742,7 +883,9 @@ RBR <- '}'
             .mark_chain(&"four".to_string(), "four".chars()).unwrap()
             .mark_chain(&"five".to_string(), "five".chars()).unwrap();
         builder
+            .accept(&"four".to_string())
             .tokenize(&"four".to_string(), &"FOUR".to_string())
+            .accept(&"five".to_string())
             .tokenize(&"five".to_string(), &"FIVE".to_string());
 
         let cdfa: EncodedCDFA<String> = builder.build().unwrap();
@@ -783,7 +926,9 @@ FIVE <- 'five'
             .mark_chain(&"FOR".to_string(), "for".chars()).unwrap()
             .default_to(&"id".to_string()).unwrap();
         builder
+            .accept(&"FOR".to_string())
             .tokenize(&"FOR".to_string(), &"FOR".to_string())
+            .accept(&"id".to_string())
             .tokenize(&"id".to_string(), &"ID".to_string());
         builder
             .default_to(&"id".to_string(), &"id".to_string()).unwrap();
@@ -811,7 +956,7 @@ ID <- 'fdk'
     #[test]
     fn scan_context_sensitive() {
         //setup
-        #[derive(PartialEq, Eq, Hash, Clone)]
+        #[derive(PartialEq, Eq, Hash, Clone, Debug)]
         enum S {
             Start,
             A,
@@ -830,19 +975,20 @@ ID <- 'fdk'
             .mark_trans(&S::BangIn, '!').unwrap();
         builder.state(&S::A)
             .mark_trans(&S::A, 'a').unwrap()
-            .tokenize(&"A".to_string());
+            .tokenize(&"A".to_string())
+            .accept();
         builder.state(&S::BangIn)
             .tokenize(&"BANG".to_string())
-            .accept_to(&S::Hidden);
+            .accept_to_from_all(&S::Hidden).unwrap();
         builder.state(&S::BangOut)
             .tokenize(&"BANG".to_string())
-            .accept_to(&S::Start);
+            .accept();
         builder.state(&S::Hidden)
             .mark_range(&S::Num, '1', '9').unwrap()
             .mark_trans(&S::BangOut, '!').unwrap();
         builder.state(&S::Num)
             .tokenize(&"NUM".to_string())
-            .accept_to(&S::Hidden);
+            .accept_to_from_all(&S::Hidden).unwrap();
 
         let cdfa: EncodedCDFA<String> = builder.build().unwrap();
 
@@ -871,6 +1017,47 @@ NUM <- '9'
 NUM <- '1'
 NUM <- '3'
 BANG <- '!'
+A <- 'a'
+");
+    }
+
+    #[test]
+    fn multiple_acceptor_destinations() {
+        //setup
+        #[derive(PartialEq, Eq, Hash, Clone, Debug)]
+        enum S {
+            Start,
+            A,
+            LastA,
+        }
+
+        let mut builder: EncodedCDFABuilder<S, String> = EncodedCDFABuilder::new();
+        builder
+            .set_alphabet("a".chars())
+            .mark_start(&S::Start);
+        builder.mark_trans(&S::Start, &S::A, 'a').unwrap();
+        builder.accept_to(&S::A, &S::Start, &S::LastA).unwrap();
+        builder.mark_trans(&S::LastA, &S::A, 'a').unwrap();
+        builder.accept_to(&S::A, &S::LastA, &S::Start).unwrap();
+        builder.state(&S::A).tokenize(&"A".to_string());
+
+        let cdfa: EncodedCDFA<String> = builder.build().unwrap();
+
+        let input = "aaaa".to_string();
+        let mut iter = input.chars();
+        let mut getter = || iter.next();
+        let mut stream: StreamSource<char> = StreamSource::observe(&mut getter);
+
+        let scanner = scan::def_scanner();
+
+        //exercise
+        let tokens = scanner.scan(&mut stream, &cdfa).unwrap();
+
+        //verify
+        assert_eq!(tokens_string(&tokens), "\
+A <- 'a'
+A <- 'a'
+A <- 'a'
 A <- 'a'
 ");
     }

--- a/src/core/scan/maximal_munch.rs
+++ b/src/core/scan/maximal_munch.rs
@@ -80,7 +80,7 @@ impl<State: Data, Kind: Data> Scanner<State, Kind> for MaximalMunchScanner {
                             last_accepting = ScanOneResult {
                                 scanned: consumed.iter().collect(),
                                 end_state: Some(next.clone()),
-                                next_start: cdfa.accepts_to(&next),
+                                next_start: cdfa.acceptor_destination(&next, &state),
                                 line,
                                 character,
                             };
@@ -111,13 +111,14 @@ impl<State: Data, Kind: Data> Scanner<State, Kind> for MaximalMunchScanner {
                 next_start,
                 line,
                 character,
-                cdfa
+                cdfa,
             );
 
             next_start = match result.next_start {
                 None => cdfa.start(),
                 Some(state) => state
             };
+
             line = result.line;
             character = result.character;
 

--- a/src/core/scan/mod.rs
+++ b/src/core/scan/mod.rs
@@ -30,7 +30,7 @@ pub trait CDFA<State, Kind> {
     fn transition(&self, state: &State, stream: &mut StreamConsumer<char>) -> Option<State>;
     fn has_transition(&self, state: &State, stream: &mut StreamConsumer<char>) -> bool;
     fn accepts(&self, state: &State) -> bool;
-    fn accepts_to(&self, state: &State) -> Option<State>;
+    fn acceptor_destination(&self, state: &State, from: &State) -> Option<State>;
     fn tokenize(&self, state: &State) -> Option<Kind>;
     fn start(&self) -> State;
 }
@@ -41,7 +41,17 @@ pub trait CDFABuilder<State, Kind, CDFAType> {
 
     fn set_alphabet(&mut self, chars: impl Iterator<Item=char>) -> &mut Self;
     fn accept(&mut self, state: &State) -> &mut Self;
-    fn accept_to(&mut self, state: &State, to: &State) -> &mut Self;
+    fn accept_to(
+        &mut self,
+        state: &State,
+        from: &State,
+        to: &State,
+    ) -> Result<&mut Self, CDFAError>;
+    fn accept_to_from_all(
+        &mut self,
+        state: &State,
+        to: &State,
+    ) -> Result<&mut Self, CDFAError>;
     fn mark_start(&mut self, state: &State) -> &mut Self;
     fn mark_trans(&mut self, from: &State, to: &State, on: char) -> Result<&mut Self, CDFAError>;
     fn mark_chain(

--- a/src/core/scan/mod.rs
+++ b/src/core/scan/mod.rs
@@ -30,6 +30,7 @@ pub trait CDFA<State, Kind> {
     fn transition(&self, state: &State, stream: &mut StreamConsumer<char>) -> Option<State>;
     fn has_transition(&self, state: &State, stream: &mut StreamConsumer<char>) -> bool;
     fn accepts(&self, state: &State) -> bool;
+    fn accepts_to(&self, state: &State) -> Option<State>;
     fn tokenize(&self, state: &State) -> Option<Kind>;
     fn start(&self) -> State;
 }
@@ -39,7 +40,8 @@ pub trait CDFABuilder<State, Kind, CDFAType> {
     fn build(self) -> Result<CDFAType, CDFAError>;
 
     fn set_alphabet(&mut self, chars: impl Iterator<Item=char>) -> &mut Self;
-    fn mark_accepting(&mut self, state: &State) -> &mut Self;
+    fn accept(&mut self, state: &State) -> &mut Self;
+    fn accept_to(&mut self, state: &State, to: &State) -> &mut Self;
     fn mark_start(&mut self, state: &State) -> &mut Self;
     fn mark_trans(&mut self, from: &State, to: &State, on: char) -> Result<&mut Self, CDFAError>;
     fn mark_chain(
@@ -62,8 +64,8 @@ pub trait CDFABuilder<State, Kind, CDFAType> {
         start: char,
         end: char,
     ) -> Result<&mut Self, CDFAError>;
-    fn mark_def(&mut self, from: &State, to: &State) -> Result<&mut Self, CDFAError>;
-    fn mark_token(&mut self, state: &State, token: &Kind) -> &mut Self;
+    fn default_to(&mut self, from: &State, to: &State) -> Result<&mut Self, CDFAError>;
+    fn tokenize(&mut self, state: &State, token: &Kind) -> &mut Self;
 }
 
 #[derive(Debug)]

--- a/src/core/spec.rs
+++ b/src/core/spec.rs
@@ -92,43 +92,43 @@ fn build_spec_ecdfa() -> Result<EncodedCDFA<String>, scan::CDFAError> {
 
     builder.state(&S::ID)
         .mark_range(&S::ID, '_', 'Z')?
-        .mark_token(&"ID".to_string());
+        .tokenize(&"ID".to_string());
 
     builder.state(&S::WS)
         .mark_trans(&S::WS, ' ')?
         .mark_trans(&S::WS, '\t')?
         .mark_trans(&S::WS, '\n')?
-        .mark_accepting();
+        .accept();
 
     builder.state(&S::PATT)
         .mark_trans(&S::PATTC, '`')?
-        .mark_def(&S::PATT)?;
+        .default_to(&S::PATT)?;
 
     builder.state(&S::CIL)
         .mark_trans(&S::CILC, '\'')?
         .mark_trans(&S::CILBS, '\\')?
-        .mark_def(&S::CIL)?;
+        .default_to(&S::CIL)?;
 
-    builder.mark_def(&S::CILBS, &S::CIL)?;
+    builder.default_to(&S::CILBS, &S::CIL)?;
 
     builder.mark_trans(&S::DOT, &S::RANGE, '.')?;
 
     builder.state(&S::COMMENT)
         .mark_trans(&S::FAIL, '\n')?
-        .mark_def(&S::COMMENT)?
-        .mark_accepting();
+        .default_to(&S::COMMENT)?
+        .accept();
 
     builder
-        .mark_token(&S::HAT, &"HAT".to_string())
-        .mark_token(&S::ARROW, &"ARROW".to_string())
-        .mark_token(&S::PATTC, &"PATTC".to_string())
-        .mark_token(&S::CILC, &"CILC".to_string())
-        .mark_token(&S::CILC, &"CILC".to_string())
-        .mark_token(&S::COPTID, &"COPTID".to_string())
-        .mark_token(&S::DEF, &"DEF".to_string())
-        .mark_token(&S::SEMI, &"SEMI".to_string())
-        .mark_token(&S::OR, &"OR".to_string())
-        .mark_token(&S::RANGE, &"RANGE".to_string());
+        .tokenize(&S::HAT, &"HAT".to_string())
+        .tokenize(&S::ARROW, &"ARROW".to_string())
+        .tokenize(&S::PATTC, &"PATTC".to_string())
+        .tokenize(&S::CILC, &"CILC".to_string())
+        .tokenize(&S::CILC, &"CILC".to_string())
+        .tokenize(&S::COPTID, &"COPTID".to_string())
+        .tokenize(&S::DEF, &"DEF".to_string())
+        .tokenize(&S::SEMI, &"SEMI".to_string())
+        .tokenize(&S::OR, &"OR".to_string())
+        .tokenize(&S::RANGE, &"RANGE".to_string());
 
     builder.build()
 }
@@ -321,7 +321,7 @@ fn generate_cdfa_trans<CDFABuilderType, CDFAType>(
             generate_cdfa_mtcs(matcher, sources, dest, builder)?;
         }
         "DEF" => for source in sources {
-            builder.mark_def(source, dest)?;
+            builder.default_to(source, dest)?;
         },
         &_ => panic!("Transition map input is neither CILC or DEF"),
     }
@@ -413,9 +413,9 @@ fn add_cdfa_tokenizer<CDFABuilderType, CDFAType>(
     CDFAType: CDFA<usize, String>,
     CDFABuilderType: CDFABuilder<String, String, CDFAType>
 {
-    builder.mark_accepting(state);
+    builder.accept(state);
     if kind != DEF_MATCHER {
-        builder.mark_token(state, kind);
+        builder.tokenize(state, kind);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -552,4 +552,6 @@ s -> ORPHANED;
 
         assert!(err.cause().is_none());
     }
+
+    //TODO test failures for re-mapping acceptances
 }


### PR DESCRIPTION
Allow an acceptance destination state to be specified using an arrow after a tokenization statement.
E.g. `state ^STATE -> other_start_state`.