### PR TITLE
Default next_start of mm scan to previous state rather than original

### DIFF
--- a/src/core/scan/ecdfa.rs
+++ b/src/core/scan/ecdfa.rs
@@ -974,13 +974,13 @@ ID <- 'fdk'
             .accept_to_from_all(&S::Hidden).unwrap();
         builder.state(&S::BangOut)
             .tokenize(&"BANG".to_string())
-            .accept();
+            .accept_to_from_all(&S::Start);
         builder.state(&S::Hidden)
             .mark_range(&S::Num, '1', '9').unwrap()
             .mark_trans(&S::BangOut, '!').unwrap();
         builder.state(&S::Num)
             .tokenize(&"NUM".to_string())
-            .accept_to_from_all(&S::Hidden).unwrap();
+            .accept();
 
         let cdfa: EncodedCDFA<String> = builder.build().unwrap();
 

--- a/src/core/scan/maximal_munch.rs
+++ b/src/core/scan/maximal_munch.rs
@@ -108,14 +108,14 @@ impl<State: Data, Kind: Data> Scanner<State, Kind> for MaximalMunchScanner {
         loop {
             let result: ScanOneResult<State> = scan_one(
                 stream_source,
-                next_start,
+                next_start.clone(),
                 line,
                 character,
                 cdfa,
             );
 
             next_start = match result.next_start {
-                None => cdfa.start(),
+                None => next_start,
                 Some(state) => state
             };
 

--- a/src/core/spec.rs
+++ b/src/core/spec.rs
@@ -1623,9 +1623,9 @@ a       ^A
 
 hidden
     '1' .. '9' -> num
-    '!' -> ^BANG;
+    '!' -> ^BANG -> start;
 
-num     ^NUM -> hidden;
+num     ^NUM;
 
 s -> ;";
 

--- a/tests/concept.rs
+++ b/tests/concept.rs
@@ -277,9 +277,9 @@ a       ^A
 
 hidden
     '1' .. '9' -> num
-    '!' -> ^_;
+    '!' -> ^_ -> start;
 
-num     ^NUM -> hidden
+num     ^NUM
     '1' .. '9' -> num;
 
 s
@@ -322,15 +322,15 @@ r2_dec
    '{' -> ^LBRACE_R2 -> r2_body;
 
 r1_body
-    'a' -> ^A -> r1_body
-    'b' -> ^B -> r1_body
-    '}' -> ^RBRACE;
+    'a' -> ^A
+    'b' -> ^B
+    '}' -> ^RBRACE -> start;
 
 r2_body
     '0' .. '9' -> num
-    '}' -> ^RBRACE;
+    '}' -> ^RBRACE -> start;
 
-num     ^NUM -> r2_body
+num     ^NUM
     '0' .. '9' -> num;
 
 s


### PR DESCRIPTION
If an acceptor destination is not explicitly specified, use the previous destination. This means that scanning strategies can be shared across CDFA regions, without losing the context of the region that they are being scanned from.
E.g. Each region will not need to specify their own whitespace scanning states and acceptance, instead only one shared whitespace state is needed, which will accept to whichever region it began its scan from.