### PR TITLE
Use clippy as a linter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,12 @@ notifications:
     on_success: never
     on_failure: always
 
+before_script:
+- rustup component add clippy
 script:
 - cargo clean
 - cargo build
+- cargo clippy -- -D warnings
 - cargo test
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,9 @@ before_script:
 script:
 - cargo clean
 - cargo build
-- cargo clippy -- -D warnings
+- if [[ "$TRAVIS_RUST_VERSION" == stable ]];
+    then cargo clippy -- -D warnings
+  fi
 - cargo test
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,7 @@ before_script:
 script:
 - cargo clean
 - cargo build
-- if [[ "$TRAVIS_RUST_VERSION" == stable ]];
-    then cargo clippy -- -D warnings
-  fi
+- cargo clippy -- -D warnings
 - cargo test
 
 env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,9 +1,9 @@
 [[package]]
 name = "aho-corasick"
-version = "0.6.4"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -11,7 +11,7 @@ name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -19,14 +19,14 @@ name = "atty"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "bitflags"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -36,7 +36,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -45,24 +45,15 @@ dependencies = [
 
 [[package]]
 name = "colored"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
+name = "fuchsia-cprng"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -72,43 +63,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
-version = "1.0.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.40"
+version = "0.2.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
-version = "2.0.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "num"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-bigint 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-complex 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-iter 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-iter 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-rational 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-bigint"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -117,25 +105,25 @@ name = "num-complex"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.36"
+version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.35"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -143,15 +131,15 @@ name = "num-rational"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-bigint 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.2"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -159,36 +147,58 @@ name = "padd"
 version = "0.1.0"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "colored 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "colored 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "stopwatch 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand"
-version = "0.4.2"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.40"
+version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -196,27 +206,27 @@ name = "redox_termios"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -225,10 +235,10 @@ version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -254,8 +264,8 @@ name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -269,26 +279,25 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.40"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ucd-util"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -297,16 +306,8 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "unreachable"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "utf8-ranges"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -315,13 +316,8 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "winapi"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -339,45 +335,45 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
+"checksum aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
-"checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
+"checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
-"checksum colored 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc0a60679001b62fb628c4da80e574b9645ab4646056d7c9018885efffe45533"
-"checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-"checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+"checksum colored 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6e9a455e156a4271e12fd0246238c380b1e223e3736663c7a18ed8b6362028a9"
+"checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
-"checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
-"checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
-"checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
+"checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
+"checksum libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)" = "aab692d7759f5cd8c859e169db98ae5b52c924add2af5fbbca11d12fefb567c1"
+"checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
-"checksum num-bigint 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "81b483ea42927c463e191802e7334556b48e7875297564c0e9951bd3a0ae53e3"
+"checksum num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
 "checksum num-complex 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656"
-"checksum num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f8d26da319fb45674985c78f1d1caf99aa4941f785d384a2ae36d0740bc3e2fe"
-"checksum num-iter 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "4b226df12c5a59b63569dd57fafb926d91b385dfce33d8074a412411b689d593"
+"checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
+"checksum num-iter 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "af3fdbbc3291a5464dc57b03860ec37ca6bf915ed6ee385e7c6c052c422b2124"
 "checksum num-rational 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "ee314c74bd753fc86b4780aa9475da469155f3848473a261d2d18e35245a784e"
-"checksum num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dee092fcdf725aee04dd7da1d21debff559237d49ef1cb3e69bcb8ece44c7364"
-"checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
-"checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
-"checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
+"checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
+"checksum rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)" = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
+"checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+"checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+"checksum rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
+"checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+"checksum redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)" = "423e376fffca3dfa06c9e9790a9ccd282fafb3cc6e6397d01dbf64f9bacc6b85"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
-"checksum regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "aec3f58d903a7d2a9dc2bf0e41a746f4530e0cab6b615494e058f67a3ef947fb"
-"checksum regex-syntax 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "bd90079345f4a4c3409214734ae220fd773c6f2e8a543d07370c6c1c369cfbfb"
+"checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
+"checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
 "checksum rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum stopwatch 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "3d04b5ebc78da44d3a456319d8bc2783e7d8cc7ccbb5cb4dc3f54afbd93bf728"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
-"checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
-"checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
-"checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
+"checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+"checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+"checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
-"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-"checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
+"checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
-"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-"checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
+"checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -142,7 +142,7 @@ fn fmt(matches: &ArgMatches) {
 
     let file_regex: Option<Regex> = match matches.value_of("matching") {
         None => None,
-        Some(regex) => match Regex::new(format!(r#"{}"#, regex).as_str()) {
+        Some(regex) => match Regex::new(regex) {
             Ok(fn_regex) => Some(fn_regex),
             Err(err) => {
                 logger::fatal(format!("Failed to build file name regex: {}", err));
@@ -282,7 +282,7 @@ fn format_target(
     }
 }
 
-fn track_file(file_path: &Path, spec_sha: &String) {
+fn track_file(file_path: &Path, spec_sha: &str) {
     let tracker_path_buf = tracker_for(file_path);
     let tracker_path = tracker_path_buf.as_path();
     let tracker_path_string = tracker_path.to_string_lossy().to_string();
@@ -303,7 +303,7 @@ fn track_file(file_path: &Path, spec_sha: &String) {
         Ok(mut tracker_file) => {
             let since_epoch = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
             let elapsed_millis = since_epoch.as_secs() * 1000 +
-                since_epoch.subsec_nanos() as u64 / 1_000_000;
+                u64::from(since_epoch.subsec_nanos()) / 1_000_000;
             let line = format!("{}\n{}\n", spec_sha, elapsed_millis);
 
             if let Err(err) = tracker_file.write_all(line.as_bytes()) {
@@ -315,7 +315,7 @@ fn track_file(file_path: &Path, spec_sha: &String) {
     }
 }
 
-fn needs_formatting(file_path: &Path, spec_sha: &String) -> bool {
+fn needs_formatting(file_path: &Path, spec_sha: &str) -> bool {
     if let Some(formatted_at) = formatted_at(file_path, spec_sha) {
         if let Some(modified_at) = modified_at(file_path) {
             let formatted_dur = formatted_at.duration_since(UNIX_EPOCH).unwrap();
@@ -348,7 +348,7 @@ fn modified_at(file_path: &Path) -> Option<SystemTime> {
     None
 }
 
-fn formatted_at(file_path: &Path, spec_sha: &String) -> Option<SystemTime> {
+fn formatted_at(file_path: &Path, spec_sha: &str) -> Option<SystemTime> {
     let tracker_path_buf = tracker_for(file_path);
     let tracker_path = tracker_path_buf.as_path();
     let tracker_path_string = tracker_path.to_string_lossy().to_string();

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -15,7 +15,7 @@ use {
         str::FromStr,
         sync::{
             Arc,
-            atomic::{ATOMIC_USIZE_INIT, AtomicUsize, Ordering},
+            atomic::{AtomicUsize, Ordering},
         },
         time::{Duration, SystemTime, UNIX_EPOCH},
     },
@@ -38,9 +38,9 @@ mod thread_pool;
 const TRACKER_DIR: &str = ".padd";
 const TRACKER_EXTENSION: &str = ".trk";
 
-static FORMATTED: AtomicUsize = ATOMIC_USIZE_INIT;
-static FAILED: AtomicUsize = ATOMIC_USIZE_INIT;
-static TOTAL: AtomicUsize = ATOMIC_USIZE_INIT;
+static FORMATTED: AtomicUsize = AtomicUsize::new(0);
+static FAILED: AtomicUsize = AtomicUsize::new(0);
+static TOTAL: AtomicUsize = AtomicUsize::new(0);
 
 pub fn run() {
     let matches = build_app();

--- a/src/cli/thread_pool.rs
+++ b/src/cli/thread_pool.rs
@@ -67,7 +67,7 @@ impl fmt::Display for ThreadPoolError {
 }
 
 impl error::Error for ThreadPoolError {
-    fn cause(&self) -> Option<&error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             ThreadPoolError::QueueErr(_) => None,
             ThreadPoolError::TermError(_) => None,
@@ -412,7 +412,7 @@ mod tests {
             "Error enqueuing worker job: sending on a closed channel"
         );
 
-        assert!(err.cause().is_none());
+        assert!(err.source().is_none());
     }
 
     #[test]
@@ -432,6 +432,6 @@ mod tests {
             "Error enqueuing worker termination signal: sending on a closed channel"
         );
 
-        assert!(err.cause().is_none());
+        assert!(err.source().is_none());
     }
 }

--- a/src/cli/thread_pool.rs
+++ b/src/cli/thread_pool.rs
@@ -112,7 +112,7 @@ impl WorkerMux {
                     Signal::TERM => break,
                     Signal::JOB(payload) => {
                         let worker_id = idle_workers.pop_back().unwrap();
-                        workers.get(worker_id).unwrap().run_job(payload);
+                        workers[worker_id].run_job(payload);
                     }
                 }
             }

--- a/src/core/fmt/mod.rs
+++ b/src/core/fmt/mod.rs
@@ -101,12 +101,12 @@ impl<'parse, Symbol: Data + Default + 'parse> FormatJob<'parse, Symbol> {
     ) -> String {
         let mut res: String = String::new();
         for seg in &pattern.segments {
-            match seg {
-                &Segment::Filler(ref s) => res = format!("{}{}", res, s),
-                &Segment::Substitution(ref s) => if let Some(value) = scope.get(s) {
+            match *seg {
+                Segment::Filler(ref s) => res = format!("{}{}", res, s),
+                Segment::Substitution(ref s) => if let Some(value) = scope.get(s) {
                     res = format!("{}{}", res, value);
                 },
-                &Segment::Capture(ref c) => res = format!(
+                Segment::Capture(ref c) => res = format!(
                     "{}{}", res, self.evaluate_capture(c, children, scope)
                 ),
             };
@@ -120,17 +120,17 @@ impl<'parse, Symbol: Data + Default + 'parse> FormatJob<'parse, Symbol> {
         children: &[Tree<Symbol>],
         outer_scope: &HashMap<String, String>,
     ) -> String {
-        if capture.declarations.len() > 0 {
+        if !capture.declarations.is_empty() {
             let mut inner_scope = outer_scope.clone();
             for decl in &capture.declarations {
-                match &decl.value {
-                    &Some(ref pattern) => {
+                match decl.value {
+                    Some(ref pattern) => {
                         inner_scope.insert(
                             decl.key.clone(),
                             self.fill_pattern(pattern, children, outer_scope),
                         );
                     }
-                    &None => {
+                    None => {
                         inner_scope.remove(&decl.key);
                     }
                 }

--- a/src/core/fmt/mod.rs
+++ b/src/core/fmt/mod.rs
@@ -96,7 +96,7 @@ impl<'parse, Symbol: Data + Default + 'parse> FormatJob<'parse, Symbol> {
     fn fill_pattern(
         &self,
         pattern: &Pattern,
-        children: &Vec<Tree<Symbol>>,
+        children: &[Tree<Symbol>],
         scope: &HashMap<String, String>,
     ) -> String {
         let mut res: String = String::new();
@@ -117,7 +117,7 @@ impl<'parse, Symbol: Data + Default + 'parse> FormatJob<'parse, Symbol> {
     fn evaluate_capture(
         &self,
         capture: &Capture,
-        children: &Vec<Tree<Symbol>>,
+        children: &[Tree<Symbol>],
         outer_scope: &HashMap<String, String>,
     ) -> String {
         if capture.declarations.len() > 0 {

--- a/src/core/fmt/pattern.rs
+++ b/src/core/fmt/pattern.rs
@@ -332,7 +332,7 @@ impl fmt::Display for BuildError {
 }
 
 impl error::Error for BuildError {
-    fn cause(&self) -> Option<&error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             BuildError::ScanErr(ref err) => Some(err),
             BuildError::ParseErr(ref err) => Some(err),

--- a/src/core/parse/earley.rs
+++ b/src/core/parse/earley.rs
@@ -230,24 +230,22 @@ impl<Symbol: Data + Default> Parser<Symbol> for EarleyParser {
                     ),
                 })
             }
+        } else if scan.len() == 0 {
+            Err(parse::Error {
+                message: "No tokens scanned".to_string(),
+            })
+        } else if cursor - 1 == scan.len() {
+            Err(parse::Error {
+                message: format!("Recognition failed after consuming all tokens"),
+            })
         } else {
-            if scan.len() == 0 {
-                Err(parse::Error {
-                    message: "No tokens scanned".to_string(),
-                })
-            } else if cursor - 1 == scan.len() {
-                Err(parse::Error {
-                    message: format!("Recognition failed after consuming all tokens"),
-                })
-            } else {
-                Err(parse::Error {
-                    message: format!(
-                        "Recognition failed at token {}: {}",
-                        cursor,
-                        scan[cursor - 1].to_string()
-                    ),
-                })
-            }
+            Err(parse::Error {
+                message: format!(
+                    "Recognition failed at token {}: {}",
+                    cursor,
+                    scan[cursor - 1].to_string()
+                ),
+            })
         };
 
         fn parse_tree<'scope, Symbol: Data + Default>(

--- a/src/core/parse/earley.rs
+++ b/src/core/parse/earley.rs
@@ -101,7 +101,7 @@ impl<Symbol: Data + Default> Parser<Symbol> for EarleyParser {
 
         fn scan_full<'inner, 'grammar: 'inner, Symbol: Data + Default>(
             cursor: usize,
-            scan: &Vec<Token<Symbol>>,
+            scan: &[Token<Symbol>],
             grammar: &'grammar Grammar<Symbol>,
             chart: &'inner mut RChart<'grammar, Symbol>,
             parse_chart: &mut PChart<'grammar, Symbol>,
@@ -230,13 +230,13 @@ impl<Symbol: Data + Default> Parser<Symbol> for EarleyParser {
                     ),
                 })
             }
-        } else if scan.len() == 0 {
+        } else if scan.is_empty() {
             Err(parse::Error {
                 message: "No tokens scanned".to_string(),
             })
         } else if cursor - 1 == scan.len() {
             Err(parse::Error {
-                message: format!("Recognition failed after consuming all tokens"),
+                message: "Recognition failed after consuming all tokens".to_string(),
             })
         } else {
             Err(parse::Error {
@@ -250,14 +250,14 @@ impl<Symbol: Data + Default> Parser<Symbol> for EarleyParser {
 
         fn parse_tree<'scope, Symbol: Data + Default>(
             grammar: &'scope Grammar<Symbol>,
-            scan: &'scope Vec<Token<Symbol>>,
+            scan: &'scope [Token<Symbol>],
             chart: PChart<'scope, Symbol>,
         ) -> Tree<Symbol> {
             fn recur<'scope, Symbol: Data + Default>(
                 start: Node,
                 edge: &Edge<Symbol>,
                 grammar: &'scope Grammar<Symbol>,
-                scan: &'scope Vec<Token<Symbol>>,
+                scan: &'scope [Token<Symbol>],
                 chart: &PChart<Symbol>,
             ) -> Tree<Symbol> {
                 match edge.rule {
@@ -301,7 +301,7 @@ impl<Symbol: Data + Default> Parser<Symbol> for EarleyParser {
             start: Node,
             edge: &Edge<Symbol>,
             grammar: &'scope Grammar<Symbol>,
-            scan: &'scope Vec<Token<Symbol>>,
+            scan: &'scope [Token<Symbol>],
             chart: &'scope PChart<'scope, Symbol>,
         ) -> Vec<(Node, Edge<'scope, Symbol>)> {
             let symbols: &Vec<Symbol> = &edge.rule.unwrap().rhs;
@@ -374,11 +374,11 @@ impl<'item, Symbol: Data + Default + 'item> RChart<'item, Symbol> {
     }
 
     fn row(&self, i: usize) -> &RChartRow<'item, Symbol> {
-        self.rows.get(i).unwrap()
+        &self.rows[i]
     }
 
     fn row_mut(&mut self, i: usize) -> &mut RChartRow<'item, Symbol> {
-        self.rows.get_mut(i).unwrap()
+        &mut self.rows[i]
     }
 
     #[allow(dead_code)]
@@ -466,7 +466,7 @@ impl<'item, Symbol: Data + Default + 'item> Items<'item, Symbol> {
     }
 
     fn item(&self, i: usize) -> &Item<'item, Symbol> {
-        self.items.get(i).unwrap()
+        &self.items[i]
     }
 
     fn contains(&self, item: &Item<'item, Symbol>) -> bool {
@@ -522,7 +522,7 @@ impl<'rule, Symbol: Data + Default> Data for Item<'rule, Symbol> {
             if i == self.next {
                 rule_string.push_str(". ");
             }
-            rule_string = format!("{}{:?} ", rule_string, self.rule.rhs.get(i).unwrap());
+            rule_string = format!("{}{:?} ", rule_string, self.rule.rhs[i]);
         }
         if self.next == self.rule.rhs.len() {
             rule_string.push_str(". ");
@@ -551,11 +551,11 @@ impl<'edge, Symbol: Data + Default + 'edge> PChart<'edge, Symbol> {
     }
 
     fn row(&self, i: usize) -> &PChartRow<Symbol> {
-        self.rows.get(i).unwrap()
+        &self.rows[i]
     }
 
     fn row_mut(&mut self, i: usize) -> &mut PChartRow<'edge, Symbol> {
-        self.rows.get_mut(i).unwrap()
+        &mut self.rows[i]
     }
 
     #[allow(dead_code)]
@@ -622,7 +622,7 @@ impl<'prod, Symbol: Data + Default + 'prod> Data for Edge<'prod, Symbol> {
             Some(rule) => {
                 let mut rule_string = format!("{:?} -> ", rule.lhs);
                 for i in 0..rule.rhs.len() {
-                    rule_string = format!("{}{:?} ", rule_string, rule.rhs.get(i).unwrap());
+                    rule_string = format!("{}{:?} ", rule_string, rule.rhs[i]);
                 }
                 format!("{} ({})", rule_string, self.finish)
             }

--- a/src/core/parse/grammar.rs
+++ b/src/core/parse/grammar.rs
@@ -55,7 +55,7 @@ impl<Symbol: Data + Default> GrammarBuilder<Symbol> {
     pub fn add_optional_state(&mut self, opt_state: &Symbol, dest_state: &Symbol) {
         if !self.prods_by_lhs.contains_key(opt_state) {
             self.prods_by_lhs.entry(opt_state.clone())
-                .or_insert(vec![
+                .or_insert_with(|| vec![
                     Production {
                         lhs: opt_state.clone(),
                         rhs: vec![dest_state.clone()],
@@ -136,7 +136,7 @@ impl<Symbol: Data + Default> GrammarBuilder<Symbol> {
             .for_each(|prod| {
                 for s in &prod.rhs {
                     prods_by_rhs.entry(s)
-                        .or_insert(Vec::new())
+                        .or_insert_with(Vec::new)
                         .push(prod);
                 }
 

--- a/src/core/parse/mod.rs
+++ b/src/core/parse/mod.rs
@@ -30,11 +30,11 @@ pub struct Tree<Symbol: Data + Default> {
 
 impl<Symbol: Data + Default> Tree<Symbol> {
     pub fn get_child(&self, i: usize) -> &Tree<Symbol> {
-        self.children.get(i).unwrap()
+        &self.children[i]
     }
 
     pub fn is_leaf(&self) -> bool {
-        self.children.len() == 0
+        self.children.is_empty()
     }
 
     pub fn is_empty(&self) -> bool {
@@ -53,7 +53,7 @@ impl<Symbol: Data + Default> Tree<Symbol> {
     }
 
     fn to_string_internal(&self, prefix: String, is_tail: bool) -> String {
-        if self.children.len() == 0 {
+        if self.children.is_empty() {
             format!(
                 "{}{}{}", prefix, if is_tail { "└── " } else { "├── " }, self.lhs.to_string()
             )
@@ -61,13 +61,11 @@ impl<Symbol: Data + Default> Tree<Symbol> {
             let mut builder = format!(
                 "{}{}{}", prefix, if is_tail { "└── " } else { "├── " }, self.lhs.kind().to_string()
             );
-            let mut i = 0;
             let len = self.children.len();
-            for child in &self.children {
+            for (i, child) in self.children.iter().enumerate() {
                 let margin = format!("{}{}", prefix, if is_tail { "    " } else { "│   " });
                 let child_string = child.to_string_internal(margin, i == len - 1);
                 builder = format!("{}\n{}", builder, child_string);
-                i += 1;
             }
             builder
         }

--- a/src/core/parse/mod.rs
+++ b/src/core/parse/mod.rs
@@ -107,7 +107,7 @@ impl fmt::Display for Error {
 }
 
 impl error::Error for Error {
-    fn cause(&self) -> Option<&error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         None
     }
 }

--- a/src/core/scan/ecdfa.rs
+++ b/src/core/scan/ecdfa.rs
@@ -140,13 +140,9 @@ CDFABuilder<State, Symbol, EncodedCDFA<Symbol>> for EncodedCDFABuilder<State, Sy
         let from_encoded = self.encode(from);
         let to_encoded = self.encode(to);
 
-        if !self.accepting.contains_key(&state_encoded) {
-            let mut accd_mux = AcceptorDestinationMux::new();
-            accd_mux.add_from(state, to_encoded, from_encoded)?;
-            self.accepting.insert(state_encoded, accd_mux);
-        } else if let Some(ref mut accd_mux) = self.accepting.get_mut(&state_encoded) {
-            accd_mux.add_from(state, to_encoded, from_encoded)?;
-        }
+        self.accepting.entry(state_encoded)
+            .or_insert_with(AcceptorDestinationMux::new)
+            .add_from(state, to_encoded, from_encoded)?;
 
         Ok(self)
     }
@@ -159,13 +155,9 @@ CDFABuilder<State, Symbol, EncodedCDFA<Symbol>> for EncodedCDFABuilder<State, Sy
         let state_encoded = self.encode(state);
         let to_encoded = self.encode(to);
 
-        if !self.accepting.contains_key(&state_encoded) {
-            let mut accd_mux = AcceptorDestinationMux::new();
-            accd_mux.add_from_all(state, to_encoded)?;
-            self.accepting.insert(state_encoded, accd_mux);
-        } else if let Some(ref mut accd_mux) = self.accepting.get_mut(&state_encoded) {
-            accd_mux.add_from_all(state, to_encoded)?;
-        }
+        self.accepting.entry(state_encoded)
+            .or_insert_with(AcceptorDestinationMux::new)
+            .add_from_all(state, to_encoded)?;
 
         Ok(self)
     }

--- a/src/core/scan/maximal_munch.rs
+++ b/src/core/scan/maximal_munch.rs
@@ -113,8 +113,8 @@ impl<State: Data, Symbol: Data> Scanner<State, Symbol> for MaximalMunchScanner {
                     if !remaining.is_empty() {
                         let sequence: String = (0..FAIL_SEQUENCE_LENGTH)
                             .map(|i| remaining.get(i))
-                            .filter(|opt| opt.is_some())
-                            .map(|opt| opt.unwrap())
+                            .filter(Option::is_some)
+                            .map(Option::unwrap)
                             .collect();
 
                         return Err(scan::Error {

--- a/src/core/scan/maximal_munch.rs
+++ b/src/core/scan/maximal_munch.rs
@@ -14,10 +14,10 @@ use {
 pub struct MaximalMunchScanner;
 
 impl<State: Data, Symbol: Data> Scanner<State, Symbol> for MaximalMunchScanner {
-    fn scan<'a, 'b>(
+    fn scan<'cdfa>(
         &self,
         input: &[char],
-        cdfa: &'b CDFA<State, Symbol>,
+        cdfa: &'cdfa CDFA<State, Symbol>,
     ) -> Result<Vec<Token<Symbol>>, scan::Error> {
         struct ScanOneResult<State> {
             consumed: usize,
@@ -54,9 +54,9 @@ impl<State: Data, Symbol: Data> Scanner<State, Symbol> for MaximalMunchScanner {
 
                 consumed += res.consumed;
 
-                for i in 0..res.consumed {
+                for c in remaining.iter().take(res.consumed) {
                     character += 1;
-                    if remaining[i] == '\n' {
+                    if *c == '\n' {
                         line += 1;
                         character = 1;
                     }

--- a/src/core/scan/mod.rs
+++ b/src/core/scan/mod.rs
@@ -204,3 +204,4 @@ impl error::Error for Error {
 }
 
 pub type State = String;
+pub type Kind = String;

--- a/src/core/scan/mod.rs
+++ b/src/core/scan/mod.rs
@@ -110,7 +110,7 @@ impl fmt::Display for CDFAError {
 }
 
 impl error::Error for CDFAError {
-    fn cause(&self) -> Option<&error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             CDFAError::BuildErr(_) => None,
         }
@@ -198,7 +198,7 @@ impl fmt::Display for Error {
 }
 
 impl error::Error for Error {
-    fn cause(&self) -> Option<&error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         None
     }
 }

--- a/src/core/spec/gen.rs
+++ b/src/core/spec/gen.rs
@@ -12,6 +12,7 @@ use {
             CDFABuilder,
             ecdfa::{EncodedCDFA, EncodedCDFABuilder},
             State,
+            Kind,
         },
         spec::{
             self,
@@ -25,8 +26,8 @@ use {
 
 pub fn generate_spec(
     parse: &Tree<Symbol>
-) -> Result<(EncodedCDFA<String>, Grammar<String>, Formatter), spec::GenError> {
-    let mut ecdfa_builder: EncodedCDFABuilder<String, String> = EncodedCDFABuilder::new();
+) -> Result<(EncodedCDFA<Kind>, Grammar<Kind>, Formatter), spec::GenError> {
+    let mut ecdfa_builder: EncodedCDFABuilder<String, Kind> = EncodedCDFABuilder::new();
     let mut grammar_builder = GrammarBuilder::new();
     let mut formatter_builder = FormatterBuilder::new();
 
@@ -48,11 +49,11 @@ pub fn generate_spec(
 fn traverse_spec_regions<CDFABuilderType, CDFAType>(
     regions_node: &Tree<Symbol>,
     cdfa_builder: &mut CDFABuilderType,
-    grammar_builder: &mut GrammarBuilder<String>,
+    grammar_builder: &mut GrammarBuilder<Kind>,
     formatter_builder: &mut FormatterBuilder,
 ) -> Result<(), spec::GenError> where
-    CDFAType: CDFA<usize, String>,
-    CDFABuilderType: CDFABuilder<String, String, CDFAType>
+    CDFAType: CDFA<usize, Kind>,
+    CDFABuilderType: CDFABuilder<String, Kind, CDFAType>
 {
     let mut region_handler = |inner_node: &Tree<Symbol>, region_type: &RegionType| {
         match region_type {
@@ -76,7 +77,7 @@ fn traverse_alphabet_region<CDFABuilderType, CDFAType>(
     cdfa_builder: &mut CDFABuilderType,
 ) where
     CDFAType: CDFA<usize, String>,
-    CDFABuilderType: CDFABuilder<String, String, CDFAType>
+    CDFABuilderType: CDFABuilder<String, Kind, CDFAType>
 {
     let escaped_alphabet = alphabet_node.get_child(1).lhs.lexeme().trim_matches('\'');
     let alphabet = string_utils::replace_escapes(&escaped_alphabet);
@@ -88,15 +89,15 @@ fn traverse_cdfa_region<CDFABuilderType, CDFAType>(
     cdfa_node: &Tree<Symbol>,
     cdfa_builder: &mut CDFABuilderType,
 ) -> Result<(), spec::GenError> where
-    CDFAType: CDFA<usize, String>,
-    CDFABuilderType: CDFABuilder<String, String, CDFAType>
+    CDFAType: CDFA<usize, Kind>,
+    CDFABuilderType: CDFABuilder<String, Kind, CDFAType>
 {
     generate_cdfa_states(cdfa_node.get_child(2), cdfa_builder)
 }
 
 fn traverse_grammar_region(
     grammar_node: &Tree<Symbol>,
-    grammar_builder: &mut GrammarBuilder<String>,
+    grammar_builder: &mut GrammarBuilder<Kind>,
     formatter_builder: &mut FormatterBuilder,
 ) -> Result<(), spec::GenError> {
     generate_grammar_prods(grammar_node.get_child(2), grammar_builder, formatter_builder)
@@ -106,8 +107,8 @@ fn generate_cdfa_states<CDFABuilderType, CDFAType>(
     states_node: &Tree<Symbol>,
     builder: &mut CDFABuilderType,
 ) -> Result<(), spec::GenError> where
-    CDFAType: CDFA<usize, String>,
-    CDFABuilderType: CDFABuilder<String, String, CDFAType>
+    CDFAType: CDFA<usize, Kind>,
+    CDFABuilderType: CDFABuilder<String, Kind, CDFAType>
 {
     let state_node = states_node.get_child(states_node.children.len() - 1);
 
@@ -159,8 +160,8 @@ fn generate_cdfa_trans<CDFABuilderType, CDFAType>(
     sources: &[&State],
     builder: &mut CDFABuilderType,
 ) -> Result<(), spec::GenError> where
-    CDFAType: CDFA<usize, String>,
-    CDFABuilderType: CDFABuilder<String, String, CDFAType>
+    CDFAType: CDFA<usize, Kind>,
+    CDFABuilderType: CDFABuilder<String, Kind, CDFAType>
 {
     let tran_node = trans_node.get_child(trans_node.children.len() - 1);
 
@@ -201,14 +202,15 @@ fn generate_cdfa_trans<CDFABuilderType, CDFAType>(
     }
 }
 
+#[allow(clippy::ptr_arg)]
 fn generate_cdfa_mtcs<CDFABuilderType, CDFAType>(
     mtcs_node: &Tree<Symbol>,
     sources: &[&State],
     dest: &State,
     builder: &mut CDFABuilderType,
 ) -> Result<(), spec::GenError> where
-    CDFAType: CDFA<usize, String>,
-    CDFABuilderType: CDFABuilder<String, String, CDFAType>
+    CDFAType: CDFA<usize, Kind>,
+    CDFABuilderType: CDFABuilder<String, Kind, CDFAType>
 {
     let mtc_node = mtcs_node.children.last().unwrap();
 
@@ -269,15 +271,16 @@ fn generate_cdfa_mtcs<CDFABuilderType, CDFAType>(
     }
 }
 
+#[allow(clippy::ptr_arg)]
 fn add_cdfa_tokenizer<CDFABuilderType, CDFAType, Symbol: Data + Default>(
     acceptor_node: &Tree<Symbol>,
     state: &State,
     from: Option<&State>,
-    kind: &String,
+    kind: &Kind,
     builder: &mut CDFABuilderType,
 ) -> Result<(), spec::GenError> where
-    CDFAType: CDFA<usize, String>,
-    CDFABuilderType: CDFABuilder<String, String, CDFAType>
+    CDFAType: CDFA<usize, Kind>,
+    CDFABuilderType: CDFABuilder<String, Kind, CDFAType>
 {
     let accd_opt_node = acceptor_node.get_child(2);
     if accd_opt_node.is_empty() {
@@ -298,7 +301,7 @@ fn add_cdfa_tokenizer<CDFABuilderType, CDFAType, Symbol: Data + Default>(
 
 fn generate_grammar_prods(
     prods_node: &Tree<Symbol>,
-    grammar_builder: &mut GrammarBuilder<String>,
+    grammar_builder: &mut GrammarBuilder<Kind>,
     formatter_builder: &mut FormatterBuilder,
 ) -> Result<(), spec::GenError> {
     if prods_node.children.len() == 2 {
@@ -324,7 +327,7 @@ fn generate_grammar_rhss(
     rhss_node: &Tree<Symbol>,
     lhs: &str,
     def_pattern_node: &Tree<Symbol>,
-    grammar_builder: &mut GrammarBuilder<String>,
+    grammar_builder: &mut GrammarBuilder<Kind>,
     formatter_builder: &mut FormatterBuilder,
 ) -> Result<(), spec::GenError> {
     let rhs_node = rhss_node.get_child(rhss_node.children.len() - 1);
@@ -372,7 +375,7 @@ fn generate_grammar_rhss(
 fn generate_grammar_ids(
     ids_node: &Tree<Symbol>,
     ids_accumulator: &mut Vec<String>,
-    grammar_builder: &mut GrammarBuilder<String>,
+    grammar_builder: &mut GrammarBuilder<Kind>,
 ) {
     if !ids_node.is_empty() {
         generate_grammar_ids(ids_node.get_child(0), ids_accumulator, grammar_builder);

--- a/src/core/spec/gen.rs
+++ b/src/core/spec/gen.rs
@@ -156,7 +156,7 @@ fn generate_cdfa_targets<'tree>(
 
 fn generate_cdfa_trans<CDFABuilderType, CDFAType>(
     trans_node: &Tree<Symbol>,
-    sources: &Vec<&State>,
+    sources: &[&State],
     builder: &mut CDFABuilderType,
 ) -> Result<(), spec::GenError> where
     CDFAType: CDFA<usize, String>,
@@ -203,7 +203,7 @@ fn generate_cdfa_trans<CDFABuilderType, CDFAType>(
 
 fn generate_cdfa_mtcs<CDFABuilderType, CDFAType>(
     mtcs_node: &Tree<Symbol>,
-    sources: &Vec<&State>,
+    sources: &[&State],
     dest: &State,
     builder: &mut CDFABuilderType,
 ) -> Result<(), spec::GenError> where
@@ -322,7 +322,7 @@ fn generate_grammar_prods(
 
 fn generate_grammar_rhss(
     rhss_node: &Tree<Symbol>,
-    lhs: &String,
+    lhs: &str,
     def_pattern_node: &Tree<Symbol>,
     grammar_builder: &mut GrammarBuilder<String>,
     formatter_builder: &mut FormatterBuilder,
@@ -333,11 +333,11 @@ fn generate_grammar_rhss(
     generate_grammar_ids(rhs_node.get_child(1), &mut ids, grammar_builder);
 
     let production = Production {
-        lhs: lhs.clone(),
+        lhs: lhs.to_string(),
         rhs: ids,
     };
 
-    grammar_builder.try_mark_start(lhs);
+    grammar_builder.try_mark_start(&production.lhs);
     grammar_builder.add_production(production.clone());
 
     let mut pattopt_node = rhs_node.get_child(2);

--- a/src/core/spec/mod.rs
+++ b/src/core/spec/mod.rs
@@ -57,7 +57,7 @@ impl std::fmt::Display for GenError {
 }
 
 impl error::Error for GenError {
-    fn cause(&self) -> Option<&error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             GenError::MatcherErr(_) => None,
             GenError::MappingErr(_) => None,
@@ -102,7 +102,7 @@ impl std::fmt::Display for ParseError {
 }
 
 impl error::Error for ParseError {
-    fn cause(&self) -> Option<&error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             ParseError::ScanErr(ref err) => Some(err),
             ParseError::ParseErr(ref err) => Some(err),

--- a/src/core/spec/region.rs
+++ b/src/core/spec/region.rs
@@ -105,7 +105,7 @@ impl fmt::Display for Error {
 }
 
 impl error::Error for Error {
-    fn cause(&self) -> Option<&error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             Error::MissingRequired(_) => None,
         }

--- a/src/core/util/string_utils.rs
+++ b/src/core/util/string_utils.rs
@@ -1,8 +1,7 @@
 pub fn replace_escapes(input: &str) -> String {
     let mut res = String::with_capacity(input.as_bytes().len());
-    let mut i = 0;
     let mut last_char: char = ' ';
-    for c in input.chars() {
+    for (i, c) in input.chars().enumerate() {
         let mut hit_double_slash = false;
         if i != 0 && last_char == '\\' {
             res.push(match c {
@@ -22,7 +21,6 @@ pub fn replace_escapes(input: &str) -> String {
         if !hit_double_slash {
             last_char = c;
         }
-        i += 1;
     }
     res
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ pub struct FormatJobRunner {
 }
 
 impl FormatJobRunner {
-    pub fn build(spec: &String) -> Result<FormatJobRunner, BuildError> {
+    pub fn build(spec: &str) -> Result<FormatJobRunner, BuildError> {
         let parse = spec::parse_spec(spec)?;
         let (cdfa, grammar, formatter) = spec::generate_spec(&parse)?;
         Ok(FormatJobRunner {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ impl fmt::Display for BuildError {
 }
 
 impl error::Error for BuildError {
-    fn cause(&self) -> Option<&error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             BuildError::SpecParseErr(ref err) => Some(err),
             BuildError::SpecGenErr(ref err) => Some(err),
@@ -120,7 +120,7 @@ impl fmt::Display for FormatError {
 }
 
 impl error::Error for FormatError {
-    fn cause(&self) -> Option<&error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             FormatError::ScanErr(ref err) => Some(err),
             FormatError::ParseErr(ref err) => Some(err),
@@ -175,13 +175,13 @@ grammar {
             "Failed to scan input: No accepting scans after (1,1): b..."
         );
 
-        err = err.cause().unwrap();
+        err = err.source().unwrap();
         assert_eq!(
             format!("{}", err),
             "No accepting scans after (1,1): b..."
         );
 
-        assert!(err.cause().is_none());
+        assert!(err.source().is_none());
     }
 
     #[test]
@@ -215,13 +215,13 @@ grammar {
             "Failed to parse input: Recognition failed at token 1: ACC <- 'a'"
         );
 
-        err = err.cause().unwrap();
+        err = err.source().unwrap();
         assert_eq!(
             format!("{}", err),
             "Recognition failed at token 1: ACC <- 'a'"
         );
 
-        assert!(err.cause().is_none());
+        assert!(err.source().is_none());
     }
 
     #[test]
@@ -252,19 +252,19 @@ grammar {
             ~\n\ncdfa {\n..."
         );
 
-        err = err.cause().unwrap();
+        err = err.source().unwrap();
         assert_eq!(
             format!("{}", err),
             "Scan error: No accepting scans after (2,14): ~\n\ncdfa {\n..."
         );
 
-        err = err.cause().unwrap();
+        err = err.source().unwrap();
         assert_eq!(
             format!("{}", err),
             "No accepting scans after (2,14): ~\n\ncdfa {\n..."
         );
 
-        assert!(err.cause().is_none());
+        assert!(err.source().is_none());
     }
 
     #[test]
@@ -295,19 +295,19 @@ grammar {
             TId <- 'SOMETHING'"
         );
 
-        err = err.cause().unwrap();
+        err = err.source().unwrap();
         assert_eq!(
             format!("{}", err),
             "Parse error: Recognition failed at token 10: TId <- 'SOMETHING'"
         );
 
-        err = err.cause().unwrap();
+        err = err.source().unwrap();
         assert_eq!(
             format!("{}", err),
             "Recognition failed at token 10: TId <- 'SOMETHING'"
         );
 
-        assert!(err.cause().is_none());
+        assert!(err.source().is_none());
     }
 
     #[test]
@@ -327,19 +327,19 @@ grammar {
             "Failed to parse specification: Parse error: No tokens scanned"
         );
 
-        err = err.cause().unwrap();
+        err = err.source().unwrap();
         assert_eq!(
             format!("{}", err),
             "Parse error: No tokens scanned"
         );
 
-        err = err.cause().unwrap();
+        err = err.source().unwrap();
         assert_eq!(
             format!("{}", err),
             "No tokens scanned"
         );
 
-        assert!(err.cause().is_none());
+        assert!(err.source().is_none());
     }
 
     #[test]
@@ -372,19 +372,19 @@ grammar {
             Default matcher used twice"
         );
 
-        err = err.cause().unwrap();
+        err = err.source().unwrap();
         assert_eq!(
             format!("{}", err),
             "ECDFA generation error: Failed to build CDFA: Default matcher used twice"
         );
 
-        err = err.cause().unwrap();
+        err = err.source().unwrap();
         assert_eq!(
             format!("{}", err),
             "Failed to build CDFA: Default matcher used twice"
         );
 
-        assert!(err.cause().is_none());
+        assert!(err.source().is_none());
     }
 
     #[test]
@@ -417,20 +417,20 @@ grammar {
             Transition trie is not prefix free on character 'a'"
         );
 
-        err = err.cause().unwrap();
+        err = err.source().unwrap();
         assert_eq!(
             format!("{}", err),
             "ECDFA generation error: Failed to build CDFA: \
             Transition trie is not prefix free on character 'a'"
         );
 
-        err = err.cause().unwrap();
+        err = err.source().unwrap();
         assert_eq!(
             format!("{}", err),
             "Failed to build CDFA: Transition trie is not prefix free on character 'a'"
         );
 
-        assert!(err.cause().is_none());
+        assert!(err.source().is_none());
     }
 
     #[test]
@@ -463,20 +463,20 @@ grammar {
             Transition trie is not prefix free on character 'l'"
         );
 
-        err = err.cause().unwrap();
+        err = err.source().unwrap();
         assert_eq!(
             format!("{}", err),
             "ECDFA generation error: Failed to build CDFA: \
             Transition trie is not prefix free on character 'l'"
         );
 
-        err = err.cause().unwrap();
+        err = err.source().unwrap();
         assert_eq!(
             format!("{}", err),
             "Failed to build CDFA: Transition trie is not prefix free on character 'l'"
         );
 
-        assert!(err.cause().is_none());
+        assert!(err.source().is_none());
     }
 
     #[test]
@@ -508,13 +508,13 @@ grammar {
             Range start must be one character, but was 'aa'"
         );
 
-        err = err.cause().unwrap();
+        err = err.source().unwrap();
         assert_eq!(
             format!("{}", err),
             "Matcher definition error: Range start must be one character, but was 'aa'"
         );
 
-        assert!(err.cause().is_none());
+        assert!(err.source().is_none());
     }
 
     #[test]
@@ -546,13 +546,13 @@ grammar {
             Range end must be one character, but was 'cd'"
         );
 
-        err = err.cause().unwrap();
+        err = err.source().unwrap();
         assert_eq!(
             format!("{}", err),
             "Matcher definition error: Range end must be one character, but was 'cd'"
         );
 
-        assert!(err.cause().is_none());
+        assert!(err.source().is_none());
     }
 
     #[test]
@@ -585,14 +585,14 @@ grammar {
             Orphaned terminal 'ORPHANED' is not tokenized by the ECDFA"
         );
 
-        err = err.cause().unwrap();
+        err = err.source().unwrap();
         assert_eq!(
             format!("{}", err),
             "ECDFA to grammar mapping error: \
             Orphaned terminal 'ORPHANED' is not tokenized by the ECDFA"
         );
 
-        assert!(err.cause().is_none());
+        assert!(err.source().is_none());
     }
 
     #[test]
@@ -625,21 +625,21 @@ grammar {
             State \"A\" is accepted multiple times with different destinations"
         );
 
-        err = err.cause().unwrap();
+        err = err.source().unwrap();
         assert_eq!(
             format!("{}", err),
             "ECDFA generation error: Failed to build CDFA: \
             State \"A\" is accepted multiple times with different destinations"
         );
 
-        err = err.cause().unwrap();
+        err = err.source().unwrap();
         assert_eq!(
             format!("{}", err),
             "Failed to build CDFA: \
             State \"A\" is accepted multiple times with different destinations"
         );
 
-        assert!(err.cause().is_none());
+        assert!(err.source().is_none());
     }
 
     #[test]
@@ -673,21 +673,21 @@ grammar {
             State \"A\" already has an acceptance destination from all incoming states"
         );
 
-        err = err.cause().unwrap();
+        err = err.source().unwrap();
         assert_eq!(
             format!("{}", err),
             "ECDFA generation error: Failed to build CDFA: \
             State \"A\" already has an acceptance destination from all incoming states"
         );
 
-        err = err.cause().unwrap();
+        err = err.source().unwrap();
         assert_eq!(
             format!("{}", err),
             "Failed to build CDFA: \
             State \"A\" already has an acceptance destination from all incoming states"
         );
 
-        assert!(err.cause().is_none());
+        assert!(err.source().is_none());
     }
 
     #[test]
@@ -721,21 +721,21 @@ grammar {
             State \"A\" already has an acceptance destination from a specific state"
         );
 
-        err = err.cause().unwrap();
+        err = err.source().unwrap();
         assert_eq!(
             format!("{}", err),
             "ECDFA generation error: Failed to build CDFA: \
             State \"A\" already has an acceptance destination from a specific state"
         );
 
-        err = err.cause().unwrap();
+        err = err.source().unwrap();
         assert_eq!(
             format!("{}", err),
             "Failed to build CDFA: \
             State \"A\" already has an acceptance destination from a specific state"
         );
 
-        assert!(err.cause().is_none());
+        assert!(err.source().is_none());
     }
 
     #[test]
@@ -761,19 +761,19 @@ grammar {
             "Failed to generate specification: Region error: Missing required region: 'CDFA'"
         );
 
-        err = err.cause().unwrap();
+        err = err.source().unwrap();
         assert_eq!(
             format!("{}", err),
             "Region error: Missing required region: 'CDFA'"
         );
 
-        err = err.cause().unwrap();
+        err = err.source().unwrap();
         assert_eq!(
             format!("{}", err),
             "Missing required region: 'CDFA'"
         );
 
-        assert!(err.cause().is_none());
+        assert!(err.source().is_none());
     }
 
     #[test]
@@ -804,26 +804,26 @@ grammar {
             Recognition failed after consuming all tokens"
         );
 
-        err = err.cause().unwrap();
+        err = err.source().unwrap();
         assert_eq!(
             format!("{}", err),
             "Formatter build error: Pattern parse error: \
             Recognition failed after consuming all tokens"
         );
 
-        err = err.cause().unwrap();
+        err = err.source().unwrap();
         assert_eq!(
             format!("{}", err),
             "Pattern parse error: Recognition failed after consuming all tokens"
         );
 
-        err = err.cause().unwrap();
+        err = err.source().unwrap();
         assert_eq!(
             format!("{}", err),
             "Recognition failed after consuming all tokens"
         );
 
-        assert!(err.cause().is_none());
+        assert!(err.source().is_none());
     }
 
     #[test]
@@ -854,20 +854,20 @@ grammar {
             Capture index 4 out of bounds for production \'s\' with 0 children"
         );
 
-        err = err.cause().unwrap();
+        err = err.source().unwrap();
         assert_eq!(
             format!("{}", err),
             "Formatter build error: Pattern capture error: \
             Capture index 4 out of bounds for production \'s\' with 0 children"
         );
 
-        err = err.cause().unwrap();
+        err = err.source().unwrap();
         assert_eq!(
             format!("{}", err),
             "Pattern capture error: \
             Capture index 4 out of bounds for production \'s\' with 0 children"
         );
 
-        assert!(err.cause().is_none());
+        assert!(err.source().is_none());
     }
 }


### PR DESCRIPTION
This pr adds the clippy linter to run in TravisCI and fixes all linter errors currently in the project.