### PR TITLE
Fix stack overflow due to long argument list

### DIFF
--- a/src/core/fmt/mod.rs
+++ b/src/core/fmt/mod.rs
@@ -72,6 +72,7 @@ impl<'parse, Symbol: Data + Default + 'parse> FormatJob<'parse, Symbol> {
         self.recur(self.parse, &HashMap::new())
     }
 
+    #[inline(always)]
     fn recur(&self, node: &Tree<Symbol>, scope: &HashMap<String, String>) -> String {
         if node.is_leaf() {
             if node.is_null() {
@@ -93,6 +94,7 @@ impl<'parse, Symbol: Data + Default + 'parse> FormatJob<'parse, Symbol> {
         }
     }
 
+    #[inline(always)]
     fn fill_pattern(
         &self,
         pattern: &Pattern,
@@ -114,6 +116,7 @@ impl<'parse, Symbol: Data + Default + 'parse> FormatJob<'parse, Symbol> {
         res
     }
 
+    #[inline(always)]
     fn evaluate_capture(
         &self,
         capture: &Capture,

--- a/tests/spec/java8
+++ b/tests/spec/java8
@@ -329,8 +329,13 @@ grammar {
         | expr;
     long_argument_list
         | inline_argument_list COMMA expr COMMA expr `{}{}\n[prefix]{}{}\n[prefix]{}`;
-    inline_argument_list
-        | inline_argument_list COMMA expr `{}{}\n[prefix]{}`
+    inline_argument_list #TODO replace with inline list
+        | inline_argument_list COMMA inline_argument COMMA inline_argument COMMA inline_argument COMMA inline_argument
+        | inline_argument COMMA inline_argument COMMA inline_argument COMMA inline_argument
+        | inline_argument COMMA inline_argument COMMA inline_argument
+        | inline_argument COMMA inline_argument
+        | inline_argument;
+    inline_argument
         | expr `\n[prefix]{}`;
 
     field_dec


### PR DESCRIPTION
Fixes #74. A more permanent fix for this would be to implement inline lists of symbols as a part of the grammar. This fix could be quite involved, and so it will be a separate enhancement.