### PR TITLE
Add support for ignorable terminal symbols

### DIFF
--- a/src/core/fmt/pattern.rs
+++ b/src/core/fmt/pattern.rs
@@ -3,7 +3,7 @@ use {
         data::Data,
         parse::{
             self,
-            grammar::{Grammar, GrammarBuilder},
+            grammar::{self, Grammar, GrammarBuilder},
             Production, Tree,
         },
         scan::{
@@ -145,10 +145,10 @@ impl Data for Symbol {
 }
 
 lazy_static! {
-    static ref PATTERN_GRAMMAR: Grammar<Symbol> = build_pattern_grammar();
+    static ref PATTERN_GRAMMAR: Grammar<Symbol> = build_pattern_grammar().unwrap();
 }
 
-fn build_pattern_grammar() -> Grammar<Symbol> {
+fn build_pattern_grammar() -> Result<Grammar<Symbol>, grammar::BuildError> {
     //TODO optimize for left recursion
 
     let mut builder = GrammarBuilder::new();

--- a/src/core/parse/earley.rs
+++ b/src/core/parse/earley.rs
@@ -276,7 +276,7 @@ impl<Symbol: Data + Default> Parser<Symbol> for EarleyParser {
             parse_chart: &mut PChart<'grammar, Symbol>,
         ) {
             parse_chart.row_mut(item.start).add_edge(Edge {
-                rule: Some(&item.rule),
+                rule: Some(item.rule),
                 shadow: item.shadow.clone(),
                 shadow_top: item.shadow_top,
                 finish,
@@ -337,7 +337,7 @@ impl<Symbol: Data + Default> Parser<Symbol> for EarleyParser {
                 scan: &'scope [Token<Symbol>],
                 chart: &PChart<Symbol>,
             ) -> Tree<Symbol> {
-                match &edge.rule {
+                match edge.rule {
                     None => Tree {
                         //Non-empty rhs
                         lhs: scan[start].clone(),

--- a/src/core/parse/earley.rs
+++ b/src/core/parse/earley.rs
@@ -25,6 +25,8 @@ impl<Symbol: Data + Default> Parser<Symbol> for EarleyParser {
             .for_each(|prod| {
                 chart.row_mut(0).unsafe_append(Item {
                     rule: prod,
+                    shadow: None,
+                    shadow_top: 0,
                     start: 0,
                     next: 0,
                 });
@@ -85,6 +87,8 @@ impl<Symbol: Data + Default> Parser<Symbol> for EarleyParser {
                     if grammar.is_nullable_nt(symbol) {
                         let new_item = Item {
                             rule: item.rule,
+                            shadow: item.shadow.clone(),
+                            shadow_top: item.shadow_top,
                             start: item.start,
                             next: item.next + 1,
                         };
@@ -103,7 +107,7 @@ impl<Symbol: Data + Default> Parser<Symbol> for EarleyParser {
             }
         }
 
-        fn parse_mark_full<'inner, 'grammar, Symbol: Data + Default>(
+        fn parse_mark_full<'inner, 'grammar: 'inner, Symbol: Data + Default>(
             cursor: usize,
             chart: &'inner RChart<'grammar, Symbol>,
             parse_chart: &mut PChart<'grammar, Symbol>,
@@ -124,11 +128,13 @@ impl<Symbol: Data + Default> Parser<Symbol> for EarleyParser {
                 return;
             }
 
-            let next_row = cross(
-                chart.row(cursor).incomplete().items(),
-                scan[cursor].kind(),
-                grammar,
-            );
+            let symbol = scan[cursor].kind();
+
+            let next_row = if grammar.is_ignorable(symbol) {
+                cross_ignorable(chart.row(cursor), symbol, grammar)
+            } else {
+                cross(chart.row(cursor).incomplete().items(), symbol, grammar)
+            };
 
             if next_row.is_empty() {
                 return;
@@ -149,6 +155,8 @@ impl<Symbol: Data + Default> Parser<Symbol> for EarleyParser {
             for prod in grammar.productions_for_lhs(symbol).unwrap() {
                 let new_item = Item {
                     rule: prod,
+                    shadow: None,
+                    shadow_top: 0,
                     start: cursor,
                     next: 0,
                 };
@@ -173,31 +181,93 @@ impl<Symbol: Data + Default> Parser<Symbol> for EarleyParser {
             for item in src {
                 if let Some(sym) = item.next_symbol() {
                     if sym == symbol {
-                        let mut last_item = item.clone();
-
-                        loop {
-                            last_item = Item {
-                                rule: last_item.rule,
-                                start: last_item.start,
-                                next: last_item.next + 1,
-                            };
-
-                            dest.push(last_item.clone());
-
-                            match last_item.next_symbol() {
-                                None => break,
-                                Some(sym) => {
-                                    if !grammar.is_nullable_nt(sym) {
-                                        break;
-                                    }
-                                }
-                            }
-                        }
+                        advance_past_symbol(item, &mut dest, grammar);
                     }
                 }
             }
 
             dest
+        }
+
+        fn cross_ignorable<'inner, 'grammar: 'inner, Symbol: Data + Default>(
+            src: &'inner RChartRow<'grammar, Symbol>,
+            symbol: &Symbol,
+            grammar: &'grammar Grammar<Symbol>,
+        ) -> Vec<Item<'grammar, Symbol>> {
+            let mut dest: Vec<Item<Symbol>> = Vec::new();
+
+            for item in src.incomplete.items() {
+                if item.next_symbol().unwrap() == symbol {
+                    advance_past_symbol(item, &mut dest, grammar);
+                } else {
+                    dest.push(ignore_next_symbol(item, symbol));
+                }
+            }
+
+            for item in src.complete.items() {
+                dest.push(ignore_next_symbol(item, symbol));
+            }
+
+            dest
+        }
+
+        fn advance_past_symbol<'inner, 'grammar: 'inner, Symbol: Data + Default>(
+            item: &'inner Item<'grammar, Symbol>,
+            dest: &mut Vec<Item<'grammar, Symbol>>,
+            grammar: &'grammar Grammar<Symbol>,
+        ) {
+            let mut last_item = item.clone();
+
+            loop {
+                last_item = Item {
+                    rule: last_item.rule,
+                    shadow: last_item.shadow.clone(),
+                    shadow_top: last_item.shadow_top,
+                    start: last_item.start,
+                    next: last_item.next + 1,
+                };
+
+                dest.push(last_item.clone());
+
+                match last_item.next_symbol() {
+                    None => break,
+                    Some(sym) => {
+                        if !grammar.is_nullable_nt(sym) {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        fn ignore_next_symbol<'inner, 'grammar: 'inner, Symbol: Data + Default>(
+            item: &'inner Item<'grammar, Symbol>,
+            symbol: &Symbol,
+        ) -> Item<'grammar, Symbol> {
+            let mut shadow_vec = match item.shadow {
+                Some(ref shadow_vec) => shadow_vec.clone(),
+                None => Vec::new(),
+            };
+
+            for i in item.shadow_top..item.next {
+                shadow_vec.push(ShadowSymbol {
+                    symbol: item.rule.rhs[i].clone(),
+                    spm: SymbolParseMethod::Standard,
+                });
+            }
+
+            shadow_vec.push(ShadowSymbol {
+                symbol: symbol.clone(),
+                spm: SymbolParseMethod::Ignored,
+            });
+
+            Item {
+                rule: item.rule,
+                shadow: Some(shadow_vec),
+                shadow_top: item.next,
+                start: item.start,
+                next: item.next,
+            }
         }
 
         fn mark_completed_item<'inner, 'grammar: 'inner, Symbol: Data + Default>(
@@ -206,8 +276,11 @@ impl<Symbol: Data + Default> Parser<Symbol> for EarleyParser {
             parse_chart: &mut PChart<'grammar, Symbol>,
         ) {
             parse_chart.row_mut(item.start).add_edge(Edge {
-                rule: Some(item.rule),
+                rule: Some(&item.rule),
+                shadow: item.shadow.clone(),
+                shadow_top: item.shadow_top,
                 finish,
+                spm: SymbolParseMethod::Standard,
             });
         }
 
@@ -264,7 +337,7 @@ impl<Symbol: Data + Default> Parser<Symbol> for EarleyParser {
                 scan: &'scope [Token<Symbol>],
                 chart: &PChart<Symbol>,
             ) -> Tree<Symbol> {
-                match edge.rule {
+                match &edge.rule {
                     None => Tree {
                         //Non-empty rhs
                         lhs: scan[start].clone(),
@@ -276,6 +349,7 @@ impl<Symbol: Data + Default> Parser<Symbol> for EarleyParser {
                             let mut children: Vec<Tree<Symbol>> =
                                 top_list(start, edge, grammar, chart)
                                     .iter()
+                                    .filter(|&(_, ref edge)| edge.spm != SymbolParseMethod::Ignored)
                                     .rev()
                                     .map(|&(node, ref edge)| {
                                         recur(node, &edge, grammar, scan, chart)
@@ -309,16 +383,18 @@ impl<Symbol: Data + Default> Parser<Symbol> for EarleyParser {
             grammar: &'scope Grammar<Symbol>,
             chart: &'scope PChart<'scope, Symbol>,
         ) -> Vec<(Node, Edge<'scope, Symbol>)> {
-            let symbols: &Vec<Symbol> = &edge.rule.unwrap().rhs;
-            let bottom: usize = symbols.len();
+            let bottom: usize = edge.symbols_len();
             let leaf = |depth: usize, node: Node| depth == bottom && node == edge.finish;
             let edges = |depth: usize, node: Node| -> Vec<Edge<Symbol>> {
                 if depth < bottom {
-                    let symbol = &symbols[depth];
+                    let (symbol, spm) = edge.symbol_at(depth);
                     if grammar.is_terminal(symbol) {
                         return vec![Edge {
                             rule: None,
+                            shadow: None,
+                            shadow_top: 0,
                             finish: node + 1,
+                            spm,
                         }];
                     } else {
                         return chart
@@ -502,6 +578,8 @@ impl<'scope, 'item: 'scope, Symbol: Data + Default + 'item> Iterator
 #[derive(PartialEq, Eq, Hash, Clone, Debug)]
 struct Item<'rule, Symbol: Data + Default + 'rule> {
     rule: &'rule Production<Symbol>,
+    shadow: Option<Vec<ShadowSymbol<Symbol>>>,
+    shadow_top: usize,
     start: usize,
     next: usize,
 }
@@ -532,7 +610,10 @@ impl<'rule, Symbol: Data + Default> Data for Item<'rule, Symbol> {
         if self.next == self.rule.rhs.len() {
             rule_string.push_str(". ");
         }
-        format!("{} ({:?})", rule_string, self.start)
+        format!(
+            "{} ({:?}) shadow:{:?} at {}",
+            rule_string, self.start, self.shadow, self.shadow_top
+        )
     }
 }
 
@@ -617,7 +698,38 @@ impl<'row, 'edge: 'row, Symbol: Data + Default + 'edge> Iterator
 #[derive(PartialEq, Eq, Hash, Clone, Debug)]
 struct Edge<'prod, Symbol: Data + Default + 'prod> {
     rule: Option<&'prod Production<Symbol>>,
+    shadow: Option<Vec<ShadowSymbol<Symbol>>>,
+    shadow_top: usize,
     finish: usize,
+    spm: SymbolParseMethod,
+}
+
+impl<'prod, Symbol: Data + Default + 'prod> Edge<'prod, Symbol> {
+    fn symbols_len(&self) -> usize {
+        match self.rule {
+            Some(rule) => match self.shadow {
+                Some(ref shadow) => shadow.len() + rule.rhs.len() - self.shadow_top,
+                None => rule.rhs.len(),
+            },
+            None => 0,
+        }
+    }
+
+    fn symbol_at(&self, index: usize) -> (&Symbol, SymbolParseMethod) {
+        if let Some(ref shadow) = self.shadow {
+            if index < shadow.len() {
+                let shadow_symbol = &shadow[index];
+                (&shadow_symbol.symbol, shadow_symbol.spm.clone())
+            } else {
+                (
+                    &self.rule.unwrap().rhs[index - shadow.len() + self.shadow_top],
+                    SymbolParseMethod::Standard,
+                )
+            }
+        } else {
+            (&self.rule.unwrap().rhs[index], SymbolParseMethod::Standard)
+        }
+    }
 }
 
 impl<'prod, Symbol: Data + Default + 'prod> Data for Edge<'prod, Symbol> {
@@ -629,10 +741,25 @@ impl<'prod, Symbol: Data + Default + 'prod> Data for Edge<'prod, Symbol> {
                 for i in 0..rule.rhs.len() {
                     rule_string = format!("{}{:?} ", rule_string, rule.rhs[i]);
                 }
-                format!("{} ({})", rule_string, self.finish)
+                format!(
+                    "{} ({}) shadow: {:?} at {}",
+                    rule_string, self.finish, self.shadow, self.shadow_top
+                )
             }
         }
     }
+}
+
+#[derive(PartialEq, Eq, Hash, Clone, Debug)]
+struct ShadowSymbol<Symbol: Data + Default> {
+    symbol: Symbol,
+    spm: SymbolParseMethod,
+}
+
+#[derive(PartialEq, Eq, Hash, Clone, Debug)]
+enum SymbolParseMethod {
+    Standard,
+    Ignored,
 }
 
 type Node = usize;

--- a/src/core/parse/earley.rs
+++ b/src/core/parse/earley.rs
@@ -274,7 +274,7 @@ impl<Symbol: Data + Default> Parser<Symbol> for EarleyParser {
                         lhs: Token::interior(rule.lhs.clone()),
                         children: {
                             let mut children: Vec<Tree<Symbol>> =
-                                top_list(start, edge, grammar, scan, chart)
+                                top_list(start, edge, grammar, chart)
                                     .iter()
                                     .rev()
                                     .map(|&(node, ref edge)| {
@@ -307,7 +307,6 @@ impl<Symbol: Data + Default> Parser<Symbol> for EarleyParser {
             start: Node,
             edge: &Edge<Symbol>,
             grammar: &'scope Grammar<Symbol>,
-            scan: &'scope [Token<Symbol>],
             chart: &'scope PChart<'scope, Symbol>,
         ) -> Vec<(Node, Edge<'scope, Symbol>)> {
             let symbols: &Vec<Symbol> = &edge.rule.unwrap().rhs;
@@ -317,12 +316,10 @@ impl<Symbol: Data + Default> Parser<Symbol> for EarleyParser {
                 if depth < bottom {
                     let symbol = &symbols[depth];
                     if grammar.is_terminal(symbol) {
-                        if *scan[node].kind() == *symbol {
-                            return vec![Edge {
-                                rule: None,
-                                finish: node + 1,
-                            }];
-                        }
+                        return vec![Edge {
+                            rule: None,
+                            finish: node + 1,
+                        }];
                     } else {
                         return chart
                             .row(node)

--- a/src/core/parse/grammar.rs
+++ b/src/core/parse/grammar.rs
@@ -238,7 +238,7 @@ impl fmt::Display for BuildError {
 }
 
 impl error::Error for BuildError {
-    fn cause(&self) -> Option<&error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             BuildError::NonTerminalIgnoredErr(_) => None,
         }

--- a/src/core/parse/grammar.rs
+++ b/src/core/parse/grammar.rs
@@ -12,6 +12,7 @@ pub struct Grammar<Symbol: Data + Default> {
     #[allow(dead_code)]
     non_terminals: HashSet<Symbol>,
     terminals: HashSet<Symbol>,
+    ignorable: HashSet<Symbol>,
     start: Symbol,
 }
 
@@ -22,6 +23,10 @@ impl<Symbol: Data + Default> Grammar<Symbol> {
 
     pub fn is_terminal(&self, symbol: &Symbol) -> bool {
         self.terminals.contains(symbol)
+    }
+
+    pub fn is_ignorable(&self, symbol: &Symbol) -> bool {
+        self.ignorable.contains(symbol)
     }
 
     pub fn terminals(&self) -> &HashSet<Symbol> {
@@ -143,6 +148,7 @@ impl<Symbol: Data + Default> GrammarBuilder<Symbol> {
             nss,
             non_terminals,
             terminals,
+            ignorable: self.ignorable,
             start,
         })
     }

--- a/src/core/parse/grammar.rs
+++ b/src/core/parse/grammar.rs
@@ -231,7 +231,7 @@ impl fmt::Display for BuildError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             BuildError::NonTerminalIgnoredErr(ref symbol) => {
-                write!(f, "Ignored symbol '{}' is non-terminal", symbol)
+                write!(f, "Ignored symbol '{}' is not a terminal symbol", symbol)
             }
         }
     }

--- a/src/core/parse/grammar.rs
+++ b/src/core/parse/grammar.rs
@@ -12,9 +12,6 @@ pub struct Grammar<Symbol: Data + Default> {
     #[allow(dead_code)]
     non_terminals: HashSet<Symbol>,
     terminals: HashSet<Symbol>,
-    #[allow(dead_code)]
-    ignorable: HashSet<Symbol>,
-    //TODO use this
     start: Symbol,
 }
 
@@ -137,7 +134,7 @@ impl<Symbol: Data + Default> GrammarBuilder<Symbol> {
 
         for ignored in &self.ignorable {
             if !terminals.contains(ignored) {
-                return Err(BuildError::NotTerminalIgnoredErr(ignored.to_string()));
+                return Err(BuildError::NonTerminalIgnoredErr(ignored.to_string()));
             }
         }
 
@@ -146,7 +143,6 @@ impl<Symbol: Data + Default> GrammarBuilder<Symbol> {
             nss,
             non_terminals,
             terminals,
-            ignorable: self.ignorable,
             start,
         })
     }
@@ -222,13 +218,13 @@ impl<'builder, Symbol: Data + Default> NonTerminalBuilder<'builder, Symbol> {
 
 #[derive(Debug)]
 pub enum BuildError {
-    NotTerminalIgnoredErr(String),
+    NonTerminalIgnoredErr(String),
 }
 
 impl fmt::Display for BuildError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            BuildError::NotTerminalIgnoredErr(ref symbol) => {
+            BuildError::NonTerminalIgnoredErr(ref symbol) => {
                 write!(f, "Ignored symbol '{}' is non-terminal", symbol)
             }
         }
@@ -238,7 +234,7 @@ impl fmt::Display for BuildError {
 impl error::Error for BuildError {
     fn cause(&self) -> Option<&error::Error> {
         match *self {
-            BuildError::NotTerminalIgnoredErr(_) => None,
+            BuildError::NonTerminalIgnoredErr(_) => None,
         }
     }
 }

--- a/src/core/parse/mod.rs
+++ b/src/core/parse/mod.rs
@@ -156,7 +156,7 @@ mod tests {
             "Verb runs",
         ]));
         grammar_builder.try_mark_start(&"Sentence".to_string());
-        let grammar = grammar_builder.build();
+        let grammar = grammar_builder.build().unwrap();
 
         let scan = vec![
             Token::leaf("mary".to_string(), "Hello".to_string()),
@@ -185,7 +185,7 @@ mod tests {
         let mut grammar_builder = GrammarBuilder::new();
         grammar_builder.add_productions(build_prods_from_strings(&["S BOF A EOF", "A x", "A A x"]));
         grammar_builder.try_mark_start(&"S".to_string());
-        let grammar = grammar_builder.build();
+        let grammar = grammar_builder.build().unwrap();
 
         let scan = vec![
             Token::leaf("BOF".to_string(), "a".to_string()),
@@ -220,7 +220,7 @@ mod tests {
             "expr ID",
         ]));
         grammar_builder.try_mark_start(&"S".to_string());
-        let grammar = grammar_builder.build();
+        let grammar = grammar_builder.build().unwrap();
 
         let scan = "( ID OP ID ) OP ID OP ( ID )"
             .split_whitespace()
@@ -275,7 +275,7 @@ mod tests {
             "Number NUM",
         ]));
         grammar_builder.try_mark_start(&"Sum".to_string());
-        let grammar = grammar_builder.build();
+        let grammar = grammar_builder.build().unwrap();
 
         let scan = "NUM AS LPAREN NUM MD NUM AS NUM RPAREN"
             .split_whitespace()
@@ -332,7 +332,7 @@ mod tests {
             "w WHITESPACE",
         ]));
         grammar_builder.try_mark_start(&"s".to_string());
-        let grammar = grammar_builder.build();
+        let grammar = grammar_builder.build().unwrap();
 
         let scan = "WHITESPACE LBRACKET WHITESPACE LBRACKET WHITESPACE RBRACKET WHITESPACE RBRACKET LBRACKET RBRACKET WHITESPACE".split_whitespace()
             .map(|kind| Token::leaf(kind.to_string(), "xy".to_string()))
@@ -399,7 +399,7 @@ mod tests {
             "w ",
         ]));
         grammar_builder.try_mark_start(&"s".to_string());
-        let grammar = grammar_builder.build();
+        let grammar = grammar_builder.build().unwrap();
 
         let scan = "WHITESPACE"
             .split_whitespace()
@@ -441,7 +441,7 @@ mod tests {
             "num DIGIT",
         ]));
         grammar_builder.try_mark_start(&"sum".to_string());
-        let grammar = grammar_builder.build();
+        let grammar = grammar_builder.build().unwrap();
 
         let scan = vec![
             Token::leaf("DIGIT".to_string(), "1".to_string()),
@@ -499,7 +499,7 @@ mod tests {
         let mut grammar_builder = GrammarBuilder::new();
         grammar_builder.add_productions(build_prods_from_strings(&["s "]));
         grammar_builder.try_mark_start(&"s".to_string());
-        let grammar = grammar_builder.build();
+        let grammar = grammar_builder.build().unwrap();
 
         let scan = vec![Token::leaf("kind".to_string(), "lexeme".to_string())];
 

--- a/src/core/spec/gen.rs
+++ b/src/core/spec/gen.rs
@@ -35,7 +35,7 @@ pub fn generate_spec(
     )?;
 
     let ecdfa = ecdfa_builder.build()?;
-    let grammar = grammar_builder.build();
+    let grammar = grammar_builder.build()?;
 
     orphan_check(&ecdfa, &grammar)?;
 
@@ -56,6 +56,7 @@ where
         match region_type {
             RegionType::Alphabet => traverse_alphabet_region(inner_node, cdfa_builder),
             RegionType::CDFA => traverse_cdfa_region(inner_node, cdfa_builder)?,
+            RegionType::Ignorable => traverse_ignorable_region(inner_node, grammar_builder),
             RegionType::Grammar => {
                 traverse_grammar_region(inner_node, grammar_builder, formatter_builder)?
             }
@@ -65,6 +66,14 @@ where
     };
 
     region::traverse(regions_node, &mut region_handler)
+}
+
+fn traverse_ignorable_region(
+    ignorable_node: &Tree<Symbol>,
+    grammar_builder: &mut GrammarBuilder<String>,
+) {
+    let terminal = ignorable_node.get_child(1).lhs.lexeme();
+    grammar_builder.mark_ignorable(terminal);
 }
 
 fn traverse_alphabet_region<CDFABuilderType, CDFAType>(

--- a/src/core/spec/lang.rs
+++ b/src/core/spec/lang.rs
@@ -55,10 +55,10 @@ enum S {
 }
 
 thread_local! {
-    static SPEC_ECDFA: EncodedCDFA<Symbol> = build_ecdfa().unwrap();
+    static SPEC_ECDFA: EncodedCDFA<Symbol> = build_spec_ecdfa().unwrap();
 }
 
-fn build_ecdfa() -> Result<EncodedCDFA<Symbol>, scan::CDFAError> {
+fn build_spec_ecdfa() -> Result<EncodedCDFA<Symbol>, scan::CDFAError> {
     let mut builder: EncodedCDFABuilder<S, Symbol> = EncodedCDFABuilder::new();
 
     builder

--- a/src/core/spec/mod.rs
+++ b/src/core/spec/mod.rs
@@ -36,7 +36,6 @@ pub enum GenError {
     CDFAErr(scan::CDFAError),
     FormatterErr(fmt::BuildError),
     GrammarBuildErr(grammar::BuildError),
-    PatternErr(fmt::BuildError),
     RegionErr(region::Error),
 }
 
@@ -48,7 +47,6 @@ impl std::fmt::Display for GenError {
             GenError::CDFAErr(ref err) => write!(f, "ECDFA generation error: {}", err),
             GenError::FormatterErr(ref err) => write!(f, "Formatter build error: {}", err),
             GenError::GrammarBuildErr(ref err) => write!(f, "Grammar build error: {}", err),
-            GenError::PatternErr(ref err) => write!(f, "Pattern build error: {}", err),
             GenError::RegionErr(ref err) => write!(f, "Region error: {}", err),
         }
     }
@@ -62,7 +60,6 @@ impl error::Error for GenError {
             GenError::CDFAErr(ref err) => Some(err),
             GenError::FormatterErr(ref err) => Some(err),
             GenError::GrammarBuildErr(ref err) => Some(err),
-            GenError::PatternErr(ref err) => Some(err),
             GenError::RegionErr(ref err) => Some(err),
         }
     }

--- a/src/core/spec/mod.rs
+++ b/src/core/spec/mod.rs
@@ -1,7 +1,11 @@
 use {
     core::{
         fmt::{self, Formatter},
-        parse::{self, grammar::Grammar, Tree},
+        parse::{
+            self,
+            grammar::{self, Grammar},
+            Tree,
+        },
         scan::{self, ecdfa::EncodedCDFA},
     },
     std::{self, error},
@@ -31,6 +35,8 @@ pub enum GenError {
     MappingErr(String),
     CDFAErr(scan::CDFAError),
     FormatterErr(fmt::BuildError),
+    GrammarBuildErr(grammar::BuildError),
+    PatternErr(fmt::BuildError),
     RegionErr(region::Error),
 }
 
@@ -41,6 +47,8 @@ impl std::fmt::Display for GenError {
             GenError::MappingErr(ref err) => write!(f, "ECDFA to grammar mapping error: {}", err),
             GenError::CDFAErr(ref err) => write!(f, "ECDFA generation error: {}", err),
             GenError::FormatterErr(ref err) => write!(f, "Formatter build error: {}", err),
+            GenError::GrammarBuildErr(ref err) => write!(f, "Grammar build error: {}", err),
+            GenError::PatternErr(ref err) => write!(f, "Pattern build error: {}", err),
             GenError::RegionErr(ref err) => write!(f, "Region error: {}", err),
         }
     }
@@ -53,6 +61,8 @@ impl error::Error for GenError {
             GenError::MappingErr(_) => None,
             GenError::CDFAErr(ref err) => Some(err),
             GenError::FormatterErr(ref err) => Some(err),
+            GenError::GrammarBuildErr(ref err) => Some(err),
+            GenError::PatternErr(ref err) => Some(err),
             GenError::RegionErr(ref err) => Some(err),
         }
     }
@@ -61,6 +71,12 @@ impl error::Error for GenError {
 impl From<scan::CDFAError> for GenError {
     fn from(err: scan::CDFAError) -> GenError {
         GenError::CDFAErr(err)
+    }
+}
+
+impl From<grammar::BuildError> for GenError {
+    fn from(err: grammar::BuildError) -> GenError {
+        GenError::GrammarBuildErr(err)
     }
 }
 

--- a/src/core/spec/region.rs
+++ b/src/core/spec/region.rs
@@ -8,6 +8,7 @@ use {
 
 #[derive(PartialEq, Eq, Hash, Clone, Debug)]
 pub enum RegionType {
+    Ignorable,
     Alphabet,
     CDFA,
     Grammar,
@@ -66,6 +67,7 @@ fn traverse_region_node(
 fn type_from_node(region_node: &Tree<Symbol>) -> RegionType {
     let region_symbol = &region_node.get_child(0).lhs.kind();
     match region_symbol {
+        Symbol::Ignorable => RegionType::Ignorable,
         Symbol::Alphabet => RegionType::Alphabet,
         Symbol::CDFA => RegionType::CDFA,
         Symbol::Grammar => RegionType::Grammar,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -864,4 +864,51 @@ grammar {
 
         assert!(err.source().is_none());
     }
+
+    #[test]
+    fn failed_ignorable_terminal_error() {
+        //setup
+        let spec = "
+alphabet 's'
+
+cdfa {
+    start
+        's' -> S;
+}
+
+ignore s
+
+grammar {
+    s | S;
+}
+        "
+        .to_string();
+
+        //exercise
+        let res = FormatJobRunner::build(&spec);
+
+        //verify
+        assert!(res.is_err());
+
+        let mut err: &Error = &res.err().unwrap();
+        assert_eq!(
+            format!("{}", err),
+            "Failed to generate specification: Grammar build error: Ignored symbol 's' is \
+             not a terminal symbol"
+        );
+
+        err = err.source().unwrap();
+        assert_eq!(
+            format!("{}", err),
+            "Grammar build error: Ignored symbol 's' is not a terminal symbol"
+        );
+
+        err = err.source().unwrap();
+        assert_eq!(
+            format!("{}", err),
+            "Ignored symbol 's' is not a terminal symbol"
+        );
+
+        assert!(err.source().is_none());
+    }
 }

--- a/tests/concept.rs
+++ b/tests/concept.rs
@@ -523,9 +523,44 @@ grammar {
         | C;
 }
     "
-        .to_string();
+    .to_string();
 
     let input = "caacaccccbccbcbc".to_string();
+
+    let fjr = FormatJobRunner::build(&spec).unwrap();
+
+    //exercise
+    let res = fjr.format(FormatJob::from_text(input)).unwrap();
+
+    //verify
+    assert_eq!(res, "a a a c b b b");
+}
+
+#[test]
+fn test_multiple_ignorable_terminals() {
+    //setup
+    let spec = "
+alphabet 'abc'
+
+cdfa {
+    start
+        'a' -> ^A
+        'b' -> ^B
+        'c' -> ^C;
+}
+
+ignore B
+ignore C
+
+grammar {
+    s
+        | A s B `{} {} {}`
+        | C;
+}
+    "
+    .to_string();
+
+    let input = "bcababcacbcbcbcbcbcbbcbcb".to_string();
 
     let fjr = FormatJobRunner::build(&spec).unwrap();
 

--- a/tests/concept.rs
+++ b/tests/concept.rs
@@ -501,3 +501,37 @@ alphabet 'inj '
     //verify
     assert_eq!(res, "iijijjjijijijiinjiii");
 }
+
+#[test]
+fn test_ignorable_terminals() {
+    //setup
+    let spec = "
+alphabet 'abc'
+
+cdfa {
+    start
+        'a' -> ^A
+        'b' -> ^B
+        'c' -> ^C;
+}
+
+ignore C
+
+grammar {
+    s
+        | A s B `{} {} {}`
+        | C;
+}
+    "
+        .to_string();
+
+    let input = "caacaccccbccbcbc".to_string();
+
+    let fjr = FormatJobRunner::build(&spec).unwrap();
+
+    //exercise
+    let res = fjr.format(FormatJob::from_text(input)).unwrap();
+
+    //verify
+    assert_eq!(res, "a a a c b b b");
+}


### PR DESCRIPTION
Adds a `ignore` specification region where ignorable terminals can be specified. The parse stage was modified to scan ignorable terminals into item "shadow vectors", allowing the parse tree to be constructed as if the ignored terminals were a part of the item's grammar production. This incurs a  small overhead even when ingnorable terminals are not used, however this will be improved when #32 is implemented.

Note that #32 is much more important after this change, as symbols will potentially be cloned much more often during the parse phase if shadow vectors are cloned often. If the symbols are encoded as `usize` instead of `String`, these clone operations will be much faster.

Closes #93 and unblocks #94.