### PR TITLE
Add DP bottom-up parser implementation

### DIFF
--- a/src/core/parse/grammar.rs
+++ b/src/core/parse/grammar.rs
@@ -39,6 +39,10 @@ impl<Symbol: Data + Default> Grammar<Symbol> {
     pub fn productions_for_lhs(&self, lhs: &Symbol) -> Option<&Vec<Production<Symbol>>> {
         self.prods_by_lhs.get(lhs)
     }
+
+    pub fn weighted_parse(&self) -> bool {
+        !self.ignorable.is_empty()
+    }
 }
 
 pub struct GrammarBuilder<Symbol: Data + Default> {

--- a/tests/spec/java8
+++ b/tests/spec/java8
@@ -232,12 +232,12 @@ cdfa {
     ws      ^_
         ' ' | '\t' | '\n' | '\r' -> ws;
 
-    lcom    ^LCOM
+    lcom    ^_
         '\n' -> fail
         _ -> lcom;
 
     bcom
-        '*/' -> bcomm
+        '*/' -> bcomm # TODO get rid of this after introducing comments
         _ -> bcom;
 
     bcomm   ^_; # TODO get rid of this after introducing comments
@@ -251,8 +251,6 @@ cdfa {
     id      ^ID
         '_' .. '9' | '$' -> id;
 }
-
-ignore LCOM
 
 grammar {
     cmp_unit
@@ -612,17 +610,17 @@ grammar {
         | inline_isolated_block_statement
         | grouped_statements;
 
-    isolated_block_statement `{}{}\n`
-        | [comment] class_dec
-        | [comment] block
-        | [comment] lvar_dec_statement `{}{}`
-        | [comment] isolated_statement;
+    isolated_block_statement `{}\n`
+        | class_dec
+        | block
+        | lvar_dec_statement `{}`
+        | isolated_statement;
 
     inline_isolated_block_statement
-        | [comment] class_dec
-        | [comment] block
-        | [comment] lvar_dec_statement
-        | [comment] isolated_statement;
+        | class_dec
+        | block
+        | lvar_dec_statement
+        | isolated_statement;
 
     lvar_dec_statement
         | lvar_dec SEMI;
@@ -646,8 +644,8 @@ grammar {
         | isolated_statement_no_if;
 
     grouped_statements
-        | [comment] grouped_statement grouped_statements `{}{}\n[prefix]{}`
-        | [comment] grouped_statement;
+        | grouped_statement grouped_statements `{}\n[prefix]{}`
+        | grouped_statement;
     grouped_statement
         | labeled_statement
         | SEMI
@@ -1031,11 +1029,4 @@ grammar {
         | STAR
         | PCT
         | SLASH;
-
-    #
-    # OPERATORS
-    #
-
-    comment
-        | LCOM `{}\n[prefix]`;
 }

--- a/tests/spec/java8
+++ b/tests/spec/java8
@@ -232,12 +232,12 @@ cdfa {
     ws      ^_
         ' ' | '\t' | '\n' | '\r' -> ws;
 
-    lcom    ^_
+    lcom    ^LCOM
         '\n' -> fail
         _ -> lcom;
 
     bcom
-        '*/' -> bcomm # TODO get rid of this after introducing comments
+        '*/' -> bcomm
         _ -> bcom;
 
     bcomm   ^_; # TODO get rid of this after introducing comments
@@ -251,6 +251,8 @@ cdfa {
     id      ^ID
         '_' .. '9' | '$' -> id;
 }
+
+ignore LCOM
 
 grammar {
     cmp_unit
@@ -610,17 +612,17 @@ grammar {
         | inline_isolated_block_statement
         | grouped_statements;
 
-    isolated_block_statement `{}\n`
-        | class_dec
-        | block
-        | lvar_dec_statement `{}`
-        | isolated_statement;
+    isolated_block_statement `{}{}\n`
+        | [comment] class_dec
+        | [comment] block
+        | [comment] lvar_dec_statement `{}{}`
+        | [comment] isolated_statement;
 
     inline_isolated_block_statement
-        | class_dec
-        | block
-        | lvar_dec_statement
-        | isolated_statement;
+        | [comment] class_dec
+        | [comment] block
+        | [comment] lvar_dec_statement
+        | [comment] isolated_statement;
 
     lvar_dec_statement
         | lvar_dec SEMI;
@@ -644,8 +646,8 @@ grammar {
         | isolated_statement_no_if;
 
     grouped_statements
-        | grouped_statement grouped_statements `{}\n[prefix]{}`
-        | grouped_statement;
+        | [comment] grouped_statement grouped_statements `{}{}\n[prefix]{}`
+        | [comment] grouped_statement;
     grouped_statement
         | labeled_statement
         | SEMI
@@ -1029,4 +1031,11 @@ grammar {
         | STAR
         | PCT
         | SLASH;
+
+    #
+    # OPERATORS
+    #
+
+    comment
+        | LCOM `{}\n[prefix]`;
 }


### PR DESCRIPTION
The bottom up parser correctly parses a weighted graph of completed edges. This parser must be used to correctly implement ignorable and injectable terminals, so that trees with less ignored terminals are favored. The previous implementation worked only when the ingored terminal was close in depth to the target, but not when they are far apart.

For grammars that do not require weighted parse tree's, the normal top down parser will still be used, since it is roughly 30% faster.