### PR TITLE
Java8 Formatting With Line Comments

### DIFF
--- a/src/core/fmt/mod.rs
+++ b/src/core/fmt/mod.rs
@@ -363,9 +363,7 @@ impl<'parse, Symbol: GrammarSymbol + 'parse> FormatJob<'parse, Symbol> {
         scope: &HashMap<String, String>,
     ) -> String {
         match injection.pattern {
-            Some(ref pattern) => {
-                self.fill_pattern_inner(pattern, &[injection.tree], scope, None)
-            }
+            Some(ref pattern) => self.fill_pattern_inner(pattern, &[injection.tree], scope, None),
             None => injection.tree.lhs.lexeme().clone(),
         }
     }

--- a/src/core/fmt/mod.rs
+++ b/src/core/fmt/mod.rs
@@ -332,7 +332,7 @@ impl<'parse, Symbol: GrammarSymbol + 'parse> FormatJob<'parse, Symbol> {
         let mut postfix = String::new();
 
         if let Some(injections) = injections_opt {
-            for injection in injections {
+            for injection in injections.iter().rev() {
                 let injection_string = match injection.pattern {
                     Some(ref pattern) => {
                         self.fill_pattern_inner(pattern, &[injection.tree], outer_scope, None)

--- a/src/core/parse/earley.rs
+++ b/src/core/parse/earley.rs
@@ -1089,7 +1089,9 @@ impl<'prod, Symbol: GrammarSymbol + 'prod> Edge<'prod, Symbol> {
     }
 
     fn is_terminal(&self, grammar: &Grammar<Symbol>) -> bool {
-        self.rule.unwrap().rhs.len() == 1 && !grammar.is_non_terminal(&self.rule.unwrap().rhs[0])
+        self.rule.unwrap().rhs.len() == 1
+            && !grammar.is_non_terminal(&self.rule.unwrap().rhs[0])
+            && self.shadow.is_none()
     }
 
     fn is_empty(&self) -> bool {

--- a/src/core/parse/mod.rs
+++ b/src/core/parse/mod.rs
@@ -777,6 +777,34 @@ mod tests {
         );
     }
 
+    #[test]
+    fn injection_into_single_terminal() {
+        //setup
+        let mut grammar_builder = SimpleGrammarBuilder::new();
+        add_productions(&["s A"], &mut grammar_builder);
+        grammar_builder.try_mark_start(&"s".to_string());
+        grammar_builder.mark_injectable(&"B".to_string(), InjectionAffinity::Right);
+        let grammar = grammar_builder.build().unwrap();
+
+        let scan = vec![
+            Token::leaf("B".to_string(), "b".to_string()),
+            Token::leaf("A".to_string(), "a".to_string()),
+        ];
+
+        let parser = def_parser();
+
+        //exercise
+        let tree = parser.parse(scan, &grammar);
+
+        //verify
+        assert_eq!(
+            tree.unwrap().to_string(),
+            "└── s
+    ├── << B <- 'b'
+    └── A <- 'a'"
+        );
+    }
+
     pub fn add_productions<'scope>(
         strings: &'scope [&'scope str],
         grammar_builder: &mut SimpleGrammarBuilder<String>,

--- a/tests/concept.rs
+++ b/tests/concept.rs
@@ -642,7 +642,7 @@ grammar {
     let res = fjr.format(FormatJob::from_text(input)).unwrap();
 
     //verify
-    assert_eq!(res, "d <c>a a da a <c>  b b <c> [d]  b bd <c>d");
+    assert_eq!(res, " <c>da a da a <c>  b b <c> [d]  b bd <c>d");
 }
 
 #[test]

--- a/tests/input/java8_line_comments
+++ b/tests/input/java8_line_comments
@@ -85,7 +85,15 @@ public class DoublyLinkedList<T> implements Iterable<T> {
         }
     }
 
+    // ---------------------------------------------------------------------- //
+// HERE IS A LARGE FLOATING COMMENT                                       //
+        // ---------------------------------------------------------------------- //
+
     private boolean removeIfLast(){
+
+
+            // Here is a small floating comment
+
         if(isEmpty()){
             return true;
         }

--- a/tests/input/java8_line_comments
+++ b/tests/input/java8_line_comments
@@ -1,0 +1,150 @@
+// Here is where the license goes
+// and here
+// and here
+    // ...
+        // ...
+            // ...
+                // ...
+                    // ...
+                // ...
+            // ...
+        // ...
+    // ...
+// ...
+// and now its done.
+package com.konjex.util;
+
+// Something
+import org.jetbrains.annotations.NotNull; // Why is there a comment here?
+
+import java.util.Iterator;
+
+// Here is some comment about the class
+// It does x, y, z.
+// For more information see https://www.moreinfo.com/?
+public class DoublyLinkedList<T> implements Iterable<T> {
+
+    // Start of the linked list
+    private LinkedListNode<T> first;
+    private LinkedListNode<T> last; // End of the linked list
+    private int length;
+
+    // Default constructor
+    public DoublyLinkedList(){
+        // No-op
+    }
+
+    public DoublyLinkedList(
+    T... elements // This is a strange place for a comment
+    ){
+// Just add all the elements
+        for(T element : elements){
+            addLast(element);
+        }
+    }
+
+    public void addFirst(T value){
+        if(isEmpty()){
+            first = new LinkedListNode<>(value, null, null);
+            last = first;
+        }
+        else{
+            LinkedListNode<T> newNode = new LinkedListNode<>(value, null, first);
+            first.setPrev(newNode); // Append to the front
+            first = newNode;
+        }
+        length ++;
+    }
+
+// Add an element to the end of the linked list.
+// Never throws.
+    public void addLast(T value){
+        if(isEmpty()){
+            first = new LinkedListNode<>(value, null, null);
+            last = first;
+        }
+        else{
+            LinkedListNode<T> newNode = new LinkedListNode<>(value, last, null);
+            last.setNext(newNode);
+            last = newNode;
+        }
+        length ++;
+    }
+
+    public void removeFirst(){
+        if(!removeIfLast()){
+            first = first.getNext();
+            first.setPrev(null);
+        }
+    }
+
+    public void removeLast(){
+        if(!removeIfLast()){
+            last = last.getPrev();
+            last.setNext(null);
+        }
+    }
+
+    private boolean removeIfLast(){
+        if(isEmpty()){
+            return true;
+        }
+        // Decrement length
+        length --;
+        // Reset first and last pointers if the list is now empty.
+        // Return true if this is the case.
+        if(length == 0){
+            first = null;
+            last = null;
+            return true;
+        }
+        return false; // Return false only if there are remaining elements
+    }
+
+    public boolean isEmpty(){
+        return first == null;
+    }
+
+    public LinkedListNode<T> getFirst(){
+        return first;
+    }
+
+    public LinkedListNode<T> getLast(){
+        return last;
+    }
+
+    public int size(){
+        return length;
+    }
+
+    @NotNull
+    @Override
+    public Iterator<T> iterator(){
+        return new Iterator<T>(){ // A
+            private LinkedListNode<T> currentNode = first;
+
+            @Override
+            public boolean hasNext() {
+                // Test1
+    // Test2
+                return !isEmpty() && currentNode.hasNext();
+            }
+
+            @Override
+            public T next() {
+                T value = currentNode       // This is a strange place for a comment
+                            .getValue();
+                currentNode = currentNode
+                                .getNext() // This place is even stranger
+                                ;
+                return value;
+            }
+
+            @Override // This method overrides a method on Iterator
+            public void remove() {
+                // We don't allow element removal via this iterator
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+}

--- a/tests/output/java8_complex_guice
+++ b/tests/output/java8_complex_guice
@@ -23,6 +23,7 @@ import java.util.Set;
 final class InheritingState implements State {
     private final State parent;
 
+    // Must be a linked hashmap in order to preserve order of bindings in Modules.
     private final Map<Key<?>, Binding<?>> explicitBindingsMutable = Maps.newLinkedHashMap();
 
     private final Map<Key<?>, Binding<?>> explicitBindings = Collections.unmodifiableMap(explicitBindingsMutable);
@@ -55,7 +56,7 @@ final class InheritingState implements State {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings("unchecked") /* we only put in BindingImpls that match their key types */
     public <T> BindingImpl<T> getExplicitBinding(Key<T> key) {
         Binding<?> binding = explicitBindings.get(key);
         return binding != null ? (BindingImpl<T>)binding : parent.getExplicitBinding(key);

--- a/tests/output/java8_complex_spring
+++ b/tests/output/java8_complex_spring
@@ -31,6 +31,7 @@ public final class CollectionFactory {
     private static final Set<Class<?>> approximableMapTypes = new HashSet<>();
 
     static {
+        // Standard collection interfaces
         approximableCollectionTypes.add(Collection.class);
         approximableCollectionTypes.add(List.class);
         approximableCollectionTypes.add(Set.class);
@@ -39,6 +40,7 @@ public final class CollectionFactory {
         approximableMapTypes.add(Map.class);
         approximableMapTypes.add(SortedMap.class);
         approximableMapTypes.add(NavigableMap.class);
+        // Common concrete collection classes
         approximableCollectionTypes.add(ArrayList.class);
         approximableCollectionTypes.add(LinkedList.class);
         approximableCollectionTypes.add(HashSet.class);
@@ -65,6 +67,7 @@ public final class CollectionFactory {
         } else if (collection instanceof List) {
             return new ArrayList<>(capacity);
         } else if (collection instanceof EnumSet) {
+            // Cast is necessary for compilation in Eclipse 4.4.1.
             Collection<E> enumSet = (Collection<E>)EnumSet.copyOf((EnumSet)collection);
             enumSet.clear();
             return enumSet;
@@ -103,6 +106,7 @@ public final class CollectionFactory {
             }
         } else if (EnumSet.class == collectionType) {
             Assert.notNull(elementType, "Cannot create EnumSet for unknown element type");
+            // Cast is necessary for compilation in Eclipse 4.4.1.
             return (Collection<E>)EnumSet.noneOf(asEnumType(elementType));
         } else {
             if (!Collection.class.isAssignableFrom(collectionType)) {

--- a/tests/output/java8_inline
+++ b/tests/output/java8_inline
@@ -2,6 +2,7 @@ package com.padd.tests;
 
 public class InlineStatements {
     public void test() {
+        // Normal if-then
         if (x) {
             call();
             call();
@@ -10,10 +11,12 @@ public class InlineStatements {
             int x = y;
         }
 
+        // Inline if-then
         if (x) {
             call();
         }
 
+        // Normal if-then-else
         if (x) {
             call();
             call();
@@ -22,12 +25,7 @@ public class InlineStatements {
             call();
         }
 
-        if (x) {
-            call();
-        } else {
-            call();
-        }
-
+        // Inline if-then-else
         if (x) {
             call();
         } else {
@@ -40,6 +38,24 @@ public class InlineStatements {
             call();
         }
 
+        if (x) {
+            call();
+        } else {
+            call();
+        }
+
+        // Normal if-then-else if
+        if (x) {
+            call();
+        } else if (y) {
+            call();
+        } else if (z) {
+            call();
+        } else {
+            call();
+        }
+
+        // Inline if-then-else if
         if (x) {
             call();
         } else if (y) {
@@ -70,32 +86,27 @@ public class InlineStatements {
             call();
         }
 
-        if (x) {
-            call();
-        } else if (y) {
-            call();
-        } else if (z) {
-            call();
-        } else {
-            call();
-        }
-
+        // Normal while
         while (x) {
             call();
         }
 
+        // Inline while
         while (x) {
             call();
         }
 
+        // Normal do-while
         do {
             call();
         } while (x);
 
+        // Inline do-while
         do {
             call();
         } while (x);
 
+        // Normal for
         for (int i = 0; i < x; ++i) {
             call();
         }
@@ -104,6 +115,7 @@ public class InlineStatements {
             call();
         }
 
+        // Inline for
         for (int i = 0; i < x; ++i) {
             call();
         }

--- a/tests/output/java8_line_comments
+++ b/tests/output/java8_line_comments
@@ -1,0 +1,173 @@
+// Here is where the license goes
+// and here
+// and here
+// ...
+// ...
+// ...
+// ...
+// ...
+// ...
+// ...
+// ...
+// ...
+// ...
+// and now its done.
+package com.konjex.util;
+
+// Something
+import org.jetbrains.annotations.NotNull;
+// Why is there a comment here?
+import java.util.Iterator;
+
+// Here is some comment about the class
+// It does x, y, z.
+// For more information see https://www.moreinfo.com/?
+public class DoublyLinkedList<T> implements Iterable<T> {
+    // Start of the linked list
+    private LinkedListNode<T> first;
+
+    private LinkedListNode<T> last;
+
+    // End of the linked list
+    private int length;
+
+    // Default constructor
+    public DoublyLinkedList() {
+    // No-op
+    }
+
+    public DoublyLinkedList(T... elements// This is a strange place for a comment
+    ) {
+        // Just add all the elements
+        for (T element : elements) {
+            addLast(element);
+        }
+    }
+
+    public void addFirst(T value) {
+        if (isEmpty()) {
+            first = new LinkedListNode<>(
+                value,
+                null,
+                null
+            );
+            last = first;
+        } else {
+            LinkedListNode<T> newNode = new LinkedListNode<>(
+                value,
+                null,
+                first
+            );
+            first.setPrev(newNode);
+            // Append to the front
+            first = newNode;
+        }
+
+        length++;
+    }
+
+    // Add an element to the end of the linked list.
+    // Never throws.
+    public void addLast(T value) {
+        if (isEmpty()) {
+            first = new LinkedListNode<>(
+                value,
+                null,
+                null
+            );
+            last = first;
+        } else {
+            LinkedListNode<T> newNode = new LinkedListNode<>(
+                value,
+                last,
+                null
+            );
+            last.setNext(newNode);
+            last = newNode;
+        }
+
+        length++;
+    }
+
+    public void removeFirst() {
+        if (!removeIfLast()) {
+            first = first.getNext();
+            first.setPrev(null);
+        }
+    }
+
+    public void removeLast() {
+        if (!removeIfLast()) {
+            last = last.getPrev();
+            last.setNext(null);
+        }
+    }
+
+    private boolean removeIfLast() {
+        if (isEmpty()) {
+            return true;
+        }
+
+        // Decrement length
+        length--;
+
+        // Reset first and last pointers if the list is now empty.
+        // Return true if this is the case.
+        if (length == 0) {
+            first = null;
+            last = null;
+            return true;
+        }
+
+        return false;
+    // Return false only if there are remaining elements
+    }
+
+    public boolean isEmpty() {
+        return first == null;
+    }
+
+    public LinkedListNode<T> getFirst() {
+        return first;
+    }
+
+    public LinkedListNode<T> getLast() {
+        return last;
+    }
+
+    public int size() {
+        return length;
+    }
+
+    @NotNull
+    @Override
+    public Iterator<T> iterator() {
+        return new Iterator<T>() {
+            // A
+            private LinkedListNode<T> currentNode = first;
+
+            @Override
+            public boolean hasNext() {
+                // Test1
+                // Test2
+                return !isEmpty() && currentNode.hasNext();
+            }
+
+            @Override
+            public T next() {
+                T value = currentNode// This is a strange place for a comment
+                .getValue();
+                currentNode = currentNode.getNext()// This place is even stranger
+                ;
+                return value;
+            }
+
+            @Override
+            // This method overrides a method on Iterator
+            public void remove() {
+                // We don't allow element removal via this iterator
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+}

--- a/tests/output/java8_line_comments
+++ b/tests/output/java8_line_comments
@@ -99,7 +99,13 @@ public class DoublyLinkedList<T> implements Iterable<T> {
         }
     }
 
+    // ---------------------------------------------------------------------- //
+    // HERE IS A LARGE FLOATING COMMENT                                       //
+    // ---------------------------------------------------------------------- //
+
     private boolean removeIfLast() {
+        // Here is a small floating comment
+
         if (isEmpty()) {
             return true;
         }

--- a/tests/output/java8_line_comments
+++ b/tests/output/java8_line_comments
@@ -15,8 +15,7 @@
 package com.konjex.util;
 
 // Something
-import org.jetbrains.annotations.NotNull;
-// Why is there a comment here?
+import org.jetbrains.annotations.NotNull; /* Why is there a comment here? */
 import java.util.Iterator;
 
 // Here is some comment about the class
@@ -26,9 +25,8 @@ public class DoublyLinkedList<T> implements Iterable<T> {
     // Start of the linked list
     private LinkedListNode<T> first;
 
-    private LinkedListNode<T> last;
+    private LinkedListNode<T> last; /* End of the linked list */
 
-    // End of the linked list
     private int length;
 
     // Default constructor
@@ -36,8 +34,7 @@ public class DoublyLinkedList<T> implements Iterable<T> {
     // No-op
     }
 
-    public DoublyLinkedList(T... elements// This is a strange place for a comment
-    ) {
+    public DoublyLinkedList(T... elements /* This is a strange place for a comment */) {
         // Just add all the elements
         for (T element : elements) {
             addLast(element);
@@ -58,8 +55,7 @@ public class DoublyLinkedList<T> implements Iterable<T> {
                 null,
                 first
             );
-            first.setPrev(newNode);
-            // Append to the front
+            first.setPrev(newNode); /* Append to the front */
             first = newNode;
         }
 
@@ -119,8 +115,7 @@ public class DoublyLinkedList<T> implements Iterable<T> {
             return true;
         }
 
-        return false;
-    // Return false only if there are remaining elements
+        return false; /* Return false only if there are remaining elements */
     }
 
     public boolean isEmpty() {
@@ -142,8 +137,7 @@ public class DoublyLinkedList<T> implements Iterable<T> {
     @NotNull
     @Override
     public Iterator<T> iterator() {
-        return new Iterator<T>() {
-            // A
+        return new Iterator<T>() { /* A */
             private LinkedListNode<T> currentNode = first;
 
             @Override
@@ -155,15 +149,12 @@ public class DoublyLinkedList<T> implements Iterable<T> {
 
             @Override
             public T next() {
-                T value = currentNode// This is a strange place for a comment
-                .getValue();
-                currentNode = currentNode.getNext()// This place is even stranger
-                ;
+                T value = currentNode /* This is a strange place for a comment */.getValue();
+                currentNode = currentNode.getNext() /* This place is even stranger */;
                 return value;
             }
 
-            @Override
-            // This method overrides a method on Iterator
+            @Override /* This method overrides a method on Iterator */
             public void remove() {
                 // We don't allow element removal via this iterator
                 throw new UnsupportedOperationException();

--- a/tests/output/java8_line_comments
+++ b/tests/output/java8_line_comments
@@ -31,7 +31,7 @@ public class DoublyLinkedList<T> implements Iterable<T> {
 
     // Default constructor
     public DoublyLinkedList() {
-    // No-op
+        // No-op
     }
 
     public DoublyLinkedList(T... elements /* This is a strange place for a comment */) {

--- a/tests/scope.rs
+++ b/tests/scope.rs
@@ -69,6 +69,11 @@ fn test_java8_inline() {
 }
 
 #[test]
+fn test_java8_line_comments() {
+    test_fjr("java8_line_comments", "java8");
+}
+
+#[test]
 fn test_json_simple() {
     test_fjr("json_simple", "json");
 }

--- a/tests/spec/java8
+++ b/tests/spec/java8
@@ -232,15 +232,13 @@ cdfa {
     ws      ^_
         ' ' | '\t' | '\n' | '\r' -> ws;
 
-    lcom    ^_
+    lcom    ^LCOM
         '\n' -> fail
         _ -> lcom;
 
     bcom
-        '*/' -> bcomm # TODO get rid of this after introducing comments
+        '*/' -> ^_
         _ -> bcom;
-
-    bcomm   ^_; # TODO get rid of this after introducing comments
 
     MOD | ASSERT | PRIM | BREAK | CASE | CATCH | ENUM | CLASS | CONTINUE | DEFAULT | DO | ELSE | EXTENDS | FINALLY | FOR
         | IF | IMPLEMENTS | IMPORT | INSTANCEOF | NEW | PACKAGE | RETURN | SUPER | SWITCH | THIS | THROWS | TRY | VOID
@@ -251,6 +249,8 @@ cdfa {
     id      ^ID
         '_' .. '9' | '$' -> id;
 }
+
+inject right LCOM `{}\n[prefix]`
 
 grammar {
     cmp_unit

--- a/tests/spec/java8
+++ b/tests/spec/java8
@@ -622,7 +622,8 @@ grammar {
         | grouped_statements isolated_block_statement block_statements `{}\n\n[prefix]{}\n[prefix]{}`
         | grouped_statements inline_isolated_block_statement `{}\n\n[prefix]{}\n`
         | inline_isolated_block_statement
-        | grouped_statements;
+        | grouped_statements
+        | PREFIX_LCOM `{}\n`;
 
     isolated_block_statement `{}\n`
         | class_dec

--- a/tests/spec/java8
+++ b/tests/spec/java8
@@ -1,7 +1,12 @@
 alphabet '<>=+-*/\\%(){}[],.;:#!?^$@&|"\'`~ \t\n\r_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
 
 cdfa {
-    start
+    start_empty_line
+        '//' -> prefix_lcom
+        ' ' | '\t' | '\n' | '\r' -> ws
+        _ ->> ^_ -> start_non_empty_line;
+
+    start_non_empty_line
         '{' -> ^LBRACE
         '}' -> ^RBRACE
         '(' -> ^LPAREN
@@ -86,7 +91,8 @@ cdfa {
         'while' -> ^WHILE
 
         # MISC
-        ' ' | '\t' | '\n' | '\r' -> ws
+        ' ' | '\t' | '\r' -> ws
+        '\n' -> ^_ -> start_empty_line
         '#' | '$' | '`' -> fail
         _ -> id;
 
@@ -124,7 +130,7 @@ cdfa {
         '=' -> ^ASSN;
 
     slash   ^SLASH
-        '/' -> lcom
+        '/' -> inline_lcom_prefix
         '*' -> bcom
         '=' -> ^ASSN;
 
@@ -232,9 +238,16 @@ cdfa {
     ws      ^_
         ' ' | '\t' | '\n' | '\r' -> ws;
 
-    lcom    ^LCOM
+    prefix_lcom     ^PREFIX_LCOM
+            '\n' -> fail
+            _ -> prefix_lcom;
+
+    inline_lcom_prefix ^_ -> inline_lcom
+            ' ' | '\t' -> inline_lcom_prefix;
+
+    inline_lcom     ^INLINE_LCOM -> start_non_empty_line
         '\n' -> fail
-        _ -> lcom;
+        _ -> inline_lcom;
 
     bcom
         '*/' -> ^_
@@ -250,7 +263,8 @@ cdfa {
         '_' .. '9' | '$' -> id;
 }
 
-inject right LCOM `{}\n[prefix]`
+inject left INLINE_LCOM ` /* {} */`
+inject right PREFIX_LCOM `{}\n[prefix]`
 
 grammar {
     cmp_unit

--- a/tests/spec/java8
+++ b/tests/spec/java8
@@ -6,6 +6,11 @@ cdfa {
         ' ' | '\t' | '\n' | '\r' -> ws
         _ ->> ^_ -> start_non_empty_line;
 
+    start_after_prefix_lcom
+        '\n' -> ^ISO_BREAK -> start_empty_line
+        ' ' | '\t' | '\r' -> ^_
+        _ ->> ^PREFIX -> start_empty_line;
+
     start_non_empty_line
         '{' -> ^LBRACE
         '}' -> ^RBRACE
@@ -238,14 +243,14 @@ cdfa {
     ws      ^_
         ' ' | '\t' | '\n' | '\r' -> ws;
 
-    prefix_lcom     ^PREFIX_LCOM
-            '\n' -> fail
-            _ -> prefix_lcom;
+    prefix_lcom ^PREFIX_LCOM -> start_after_prefix_lcom
+        '\n' -> ^PREFIX_LCOM -> start_after_prefix_lcom
+        _ -> prefix_lcom;
 
     inline_lcom_prefix ^_ -> inline_lcom
-            ' ' | '\t' -> inline_lcom_prefix;
+        ' ' | '\t' -> inline_lcom_prefix;
 
-    inline_lcom     ^INLINE_LCOM -> start_non_empty_line
+    inline_lcom ^INLINE_LCOM -> start_non_empty_line
         '\n' -> fail
         _ -> inline_lcom;
 
@@ -264,7 +269,9 @@ cdfa {
 }
 
 inject left INLINE_LCOM ` /* {} */`
-inject right PREFIX_LCOM `{}\n[prefix]`
+inject right PREFIX_LCOM
+inject right ISO_BREAK `\n[prefix]`
+inject right PREFIX `[prefix]`
 
 grammar {
     cmp_unit
@@ -623,7 +630,7 @@ grammar {
         | grouped_statements inline_isolated_block_statement `{}\n\n[prefix]{}\n`
         | inline_isolated_block_statement
         | grouped_statements
-        | PREFIX_LCOM `{}\n`;
+        | PREFIX_LCOM PREFIX `{}`;
 
     isolated_block_statement `{}\n`
         | class_dec


### PR DESCRIPTION
Add formatting rules for block comments to the java8 spec. This base implementation will carry over easily to other languages.

This pr contributes to #11 and is effectively the first half of #34, the next step is to implement block comment formatting.