### PR TITLE
Java8 Formatting With Block Comments

### DIFF
--- a/src/core/fmt/mod.rs
+++ b/src/core/fmt/mod.rs
@@ -479,14 +479,22 @@ impl<'parse, Symbol: GrammarSymbol + 'parse> FormatJob<'parse, Symbol> {
         let mut postfix = String::new();
 
         if let Some(injections) = injections_opt {
-            for injection in injections.iter().rev() {
-                let injection_string = self.injection_string(injection, outer_scope);
+            injections
+                .iter()
+                .filter(|injection| injection.direction == InjectionAffinity::Left)
+                .for_each(|injection| {
+                    let injection_string = self.injection_string(injection, outer_scope);
+                    postfix = format!("{}{}", postfix, injection_string);
+                });
 
-                match injection.direction {
-                    InjectionAffinity::Left => postfix = format!("{}{}", postfix, injection_string),
-                    InjectionAffinity::Right => prefix = format!("{}{}", injection_string, prefix),
-                }
-            }
+            injections
+                .iter()
+                .filter(|injection| injection.direction == InjectionAffinity::Right)
+                .rev()
+                .for_each(|injection| {
+                    let injection_string = self.injection_string(injection, outer_scope);
+                    prefix = format!("{}{}", injection_string, prefix);
+                });
         }
 
         format!("{}{}{}", prefix, child_string, postfix)

--- a/tests/input/java8_block_comments
+++ b/tests/input/java8_block_comments
@@ -182,7 +182,8 @@ public class DoublyLinkedList<T> implements Iterable<T> {
     }
 
     public boolean isEmpty(){
-        return first == null;
+        return first == null; /*
+        * Return true if there is no first element */
     }
 
     public LinkedListNode<T> getFirst(){

--- a/tests/input/java8_block_comments
+++ b/tests/input/java8_block_comments
@@ -80,6 +80,20 @@ public class DoublyLinkedList<T> implements Iterable<T> {
        */
     }
 
+    public DoublyLinkedList(){
+
+        /*
+         * This lone isolated comment should be compacted!
+        */
+
+    }
+
+    public DoublyLinkedList(){
+
+        /* This lone isolated comment should be compacted! */
+
+    }
+
     public DoublyLinkedList(
     T... elements /* This is a strange place for a comment
     */){

--- a/tests/input/java8_block_comments
+++ b/tests/input/java8_block_comments
@@ -1,0 +1,183 @@
+/* Here is where the license goes
+* and here
+    * and here
+     ...
+         ...
+             ...
+                 ...
+                     ...
+                 ...
+             ...
+         ...
+     ...
+ ...
+and now its done.*/
+package com.konjex.util;
+
+/* Something */
+import org.jetbrains.annotations.NotNull; /* Why is there a comment here? */
+
+import java.util.Iterator;
+
+/**
+ Here is some comment about the class
+ It does x, y, z.
+ * For more information see https://www.moreinfo.com/? */
+public class DoublyLinkedList<T> implements Iterable<T> {
+
+    /* Start of the linked list
+     *
+     */
+    private LinkedListNode<T> first;
+    private LinkedListNode<T> last; /* End of the linked list */
+    private int length;
+
+    /* Default constructor */
+    public DoublyLinkedList(){
+        /* No-op */
+    }
+
+    public DoublyLinkedList(){
+        /*
+        No-op
+        */
+    }
+
+    public DoublyLinkedList(
+    T... elements /* This is a strange place for a comment
+    */){
+/* Just add all the elements */
+        for(T element : elements){
+            addLast(element);
+        }
+    }
+
+    public void addFirst(T value){
+        if(isEmpty()){
+            first = new LinkedListNode<>(value, null, null);
+            last = first;
+        }
+        else{
+            LinkedListNode<T> newNode = new LinkedListNode<>(value, null, first);
+            first.setPrev(newNode); /** Append to the front
+            * Then do something else
+            Then do a third thing
+*/
+            first = newNode;
+        }
+        length ++;
+    }
+
+/*
+ * Add an element to the end of the linked list.
+ * Never throws.
+ */
+    public void addLast(T value){
+        if(isEmpty()){
+            first = new LinkedListNode<>(value, null, null);
+            last = first;
+        }
+        /*
+         * Why would there be a comment between these??
+         */
+        else{
+            LinkedListNode<T> newNode = new LinkedListNode<>(value, last, null);
+            last.setNext(newNode);
+            last = newNode;
+        }
+        length ++;
+    }
+
+    public void removeFirst(){
+        if(!removeIfLast()){
+            first = first.getNext();
+            first.setPrev(null);
+        }
+    }
+
+    public void removeLast(){
+        if(!removeIfLast()){
+            last = last.getPrev();
+            last.setNext(null);
+        }
+    }
+
+    /* ----------------------------------------------------------------------
+ HERE IS A LARGE FLOATING COMMENT
+         ---------------------------------------------------------------------- */
+
+    private boolean removeIfLast(){
+
+
+            /* Here is a small floating comment */
+
+        if(isEmpty()){
+            return true;
+        }
+        /* Decrement length */
+        length --;
+        /* Reset first and last pointers if the list is now empty.
+         Return true if this is the case.
+
+         */
+        if(length == 0){
+            first = null;
+            last = null;
+            return true;
+        }
+        return false; /*
+
+         Return false only if there are remaining elements */
+    }
+
+    public boolean isEmpty(){
+        return first == null;
+    }
+
+    public LinkedListNode<T> getFirst(){
+        return first;
+    }
+
+    public LinkedListNode<T> getLast(){
+        return last;
+    }
+
+    public int size(){
+        return length;
+    }
+
+    @NotNull
+    @Override
+    public Iterator<T> iterator(){
+        return new Iterator<T>(){ /* A */
+            private LinkedListNode<T> currentNode = first;
+
+            @Override
+            public boolean hasNext() {
+                /* Test1 */
+    /* Test2 */
+                return !isEmpty() && currentNode.hasNext();
+            }
+
+            @Override
+            public T next() {
+                T value = currentNode       /* This is a strange place for a comment */
+                            .getValue();
+                currentNode = currentNode
+                                .getNext() /* This place is even stranger */
+                                ;
+                return value;
+            }
+
+            @Override /* This method overrides a method on Iterator
+
+            */
+            public void remove() {
+                /*
+                 * We don't allow element removal via this iterator
+                 */
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+}

--- a/tests/input/java8_block_comments
+++ b/tests/input/java8_block_comments
@@ -43,6 +43,43 @@ public class DoublyLinkedList<T> implements Iterable<T> {
         */
     }
 
+    public DoublyLinkedList(){/*
+            * No-op
+            */
+        }
+
+        public DoublyLinkedList(){
+                /* No-op
+                */
+            }
+
+
+    public DoublyLinkedList(){
+        /*
+        No-op
+        */
+
+        /* HERE
+        * BE
+       THERE
+...
+       EVERYWHERE*/
+    }
+
+    public DoublyLinkedList(){/*
+        No-op
+        */
+
+        /* HERE
+        * BE
+       THERE
+...
+       EVERYWHERE*//*
+       BUT WAIT!
+       THERE ARE MORE COMMENTS!!!
+       */
+    }
+
     public DoublyLinkedList(
     T... elements /* This is a strange place for a comment
     */){

--- a/tests/input/java8_interface
+++ b/tests/input/java8_interface
@@ -1,6 +1,6 @@
 package com.konjex.util.provide;
 
-/**
+/*
  * Object that can be provided by a provider.
  */
 public interface Providable<MatchType> extends DataClass {

--- a/tests/input/java8_medium
+++ b/tests/input/java8_medium
@@ -3,7 +3,7 @@ package com.konjex.lens.conf;
 import java.io.File;
 import java.util.function.Consumer;
 
-/**
+/*
  * Class for loading lens configuration files by name.
  */
 public abstract class ConfigFileLoader {

--- a/tests/output/java8_block_comments
+++ b/tests/output/java8_block_comments
@@ -87,6 +87,16 @@ public class DoublyLinkedList<T> implements Iterable<T> {
          */
     }
 
+    public DoublyLinkedList() {
+        /*
+         * This lone isolated comment should be compacted!
+         */
+    }
+
+    public DoublyLinkedList() {
+        /* This lone isolated comment should be compacted! */
+    }
+
     public DoublyLinkedList(T... elements
     /*
      * This is a strange place for a comment
@@ -170,8 +180,10 @@ public class DoublyLinkedList<T> implements Iterable<T> {
      * HERE IS A LARGE FLOATING COMMENT
      * ---------------------------------------------------------------------- 
      */
+
     private boolean removeIfLast() {
         /* Here is a small floating comment */
+
         if (isEmpty()) {
             return true;
         }

--- a/tests/output/java8_block_comments
+++ b/tests/output/java8_block_comments
@@ -39,20 +39,58 @@ public class DoublyLinkedList<T> implements Iterable<T> {
 
     /* Default constructor */
     public DoublyLinkedList() {
-    /* No-op */
+        /* No-op */
     }
 
     public DoublyLinkedList() {
-    /*
-     * No-op
-     */
+        /*
+         * No-op
+         */
+    }
+
+    public DoublyLinkedList() {
+        /*
+         * No-op
+         */
+    }
+
+    public DoublyLinkedList() {
+        /*
+         * No-op
+         */
+    }
+
+    public DoublyLinkedList() {
+        /*
+         * No-op
+         *
+         * HERE
+         * BE
+         * THERE
+         * ...
+         * EVERYWHERE
+         */
+    }
+
+    public DoublyLinkedList() {
+        /*
+         * No-op
+         *
+         * HERE
+         * BE
+         * THERE
+         * ...
+         * EVERYWHERE
+         
+         * BUT WAIT!
+         * THERE ARE MORE COMMENTS!!!
+         */
     }
 
     public DoublyLinkedList(T... elements
     /*
      * This is a strange place for a comment
-     */
-    ) {
+     */) {
         /* Just add all the elements */
         for (T element : elements) {
             addLast(element);
@@ -79,7 +117,6 @@ public class DoublyLinkedList<T> implements Iterable<T> {
              * Then do something else
              * Then do a third thing
              */
-            
             first = newNode;
         }
 
@@ -200,7 +237,6 @@ public class DoublyLinkedList<T> implements Iterable<T> {
             /*
              * This method overrides a method on Iterator
              */
-            
             public void remove() {
                 /*
                  * We don't allow element removal via this iterator

--- a/tests/output/java8_block_comments
+++ b/tests/output/java8_block_comments
@@ -1,0 +1,195 @@
+/* Here is where the license goes
+ * and here
+ * and here
+ * ...
+ * ...
+ * ...
+ * ...
+ * ...
+ * ...
+ * ...
+ * ...
+ * ...
+ * ...
+ * and now its done.*/
+package com.konjex.util;
+
+/* Something */
+import org.jetbrains.annotations.NotNull; /* Why is there a comment here? */
+import java.util.Iterator;
+
+/**
+ * Here is some comment about the class
+ * It does x, y, z.
+ * For more information see https://www.moreinfo.com/? */
+public class DoublyLinkedList<T> implements Iterable<T> {
+    /* Start of the linked list
+     *
+     */
+    private LinkedListNode<T> first;
+
+    private LinkedListNode<T> last; /* End of the linked list */
+
+    private int length;
+
+    /* Default constructor */
+    public DoublyLinkedList() {
+    /* No-op */
+    }
+
+    public DoublyLinkedList() {
+    /*
+     * No-op
+     */
+    }
+
+    public DoublyLinkedList(T... elements/* This is a strange place for a comment
+     */
+    ) {
+        /* Just add all the elements */
+        for (T element : elements) {
+            addLast(element);
+        }
+    }
+
+    public void addFirst(T value) {
+        if (isEmpty()) {
+            first = new LinkedListNode<>(
+                value,
+                null,
+                null
+            );
+            last = first;
+        } else {
+            LinkedListNode<T> newNode = new LinkedListNode<>(
+                value,
+                null,
+                first
+            );
+            first.setPrev(newNode);
+            /** Append to the front
+             * Then do something else
+             * Then do a third thing
+             */
+            first = newNode;
+        }
+
+        length++;
+    }
+
+    /*
+     * Add an element to the end of the linked list.
+     * Never throws.
+     */
+    public void addLast(T value) {
+        if (isEmpty()) {
+            first = new LinkedListNode<>(
+                value,
+                null,
+                null
+            );
+            last = first;
+        } /*
+         * Why would there be a comment between these??
+         */
+        else {
+            LinkedListNode<T> newNode = new LinkedListNode<>(
+                value,
+                last,
+                null
+            );
+            last.setNext(newNode);
+            last = newNode;
+        }
+
+        length++;
+    }
+
+    public void removeFirst() {
+        if (!removeIfLast()) {
+            first = first.getNext();
+            first.setPrev(null);
+        }
+    }
+
+    public void removeLast() {
+        if (!removeIfLast()) {
+            last = last.getPrev();
+            last.setNext(null);
+        }
+    }
+
+    /* ----------------------------------------------------------------------
+     * HERE IS A LARGE FLOATING COMMENT
+     * ---------------------------------------------------------------------- */
+    private boolean removeIfLast() {
+        /* Here is a small floating comment */
+        if (isEmpty()) {
+            return true;
+        }
+
+        /* Decrement length */
+        length--;
+
+        /* Reset first and last pointers if the list is now empty.
+         * Return true if this is the case.
+         */
+        if (length == 0) {
+            first = null;
+            last = null;
+            return true;
+        }
+
+        return false;
+    /*
+     * Return false only if there are remaining elements */
+    }
+
+    public boolean isEmpty() {
+        return first == null;
+    }
+
+    public LinkedListNode<T> getFirst() {
+        return first;
+    }
+
+    public LinkedListNode<T> getLast() {
+        return last;
+    }
+
+    public int size() {
+        return length;
+    }
+
+    @NotNull
+    @Override
+    public Iterator<T> iterator() {
+        return new Iterator<T>() { /* A */
+            private LinkedListNode<T> currentNode = first;
+
+            @Override
+            public boolean hasNext() {
+                /* Test1 */
+                /* Test2 */
+                return !isEmpty() && currentNode.hasNext();
+            }
+
+            @Override
+            public T next() {
+                T value = currentNode /* This is a strange place for a comment */.getValue();
+                currentNode = currentNode.getNext() /* This place is even stranger */;
+                return value;
+            }
+
+            @Override
+            /* This method overrides a method on Iterator
+             */
+            public void remove() {
+                /*
+                 * We don't allow element removal via this iterator
+                 */
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+}

--- a/tests/output/java8_block_comments
+++ b/tests/output/java8_block_comments
@@ -81,7 +81,6 @@ public class DoublyLinkedList<T> implements Iterable<T> {
          * THERE
          * ...
          * EVERYWHERE
-         
          * BUT WAIT!
          * THERE ARE MORE COMMENTS!!!
          */

--- a/tests/output/java8_block_comments
+++ b/tests/output/java8_block_comments
@@ -1,4 +1,5 @@
-/* Here is where the license goes
+/*
+ * Here is where the license goes
  * and here
  * and here
  * ...
@@ -11,19 +12,23 @@
  * ...
  * ...
  * ...
- * and now its done.*/
+ * and now its done.
+ */
 package com.konjex.util;
 
 /* Something */
 import org.jetbrains.annotations.NotNull; /* Why is there a comment here? */
 import java.util.Iterator;
 
-/**
+/*
+ * *
  * Here is some comment about the class
  * It does x, y, z.
- * For more information see https://www.moreinfo.com/? */
+ * For more information see https://www.moreinfo.com/? 
+ */
 public class DoublyLinkedList<T> implements Iterable<T> {
-    /* Start of the linked list
+    /*
+     * Start of the linked list
      *
      */
     private LinkedListNode<T> first;
@@ -43,7 +48,9 @@ public class DoublyLinkedList<T> implements Iterable<T> {
      */
     }
 
-    public DoublyLinkedList(T... elements/* This is a strange place for a comment
+    public DoublyLinkedList(T... elements
+    /*
+     * This is a strange place for a comment
      */
     ) {
         /* Just add all the elements */
@@ -67,10 +74,12 @@ public class DoublyLinkedList<T> implements Iterable<T> {
                 first
             );
             first.setPrev(newNode);
-            /** Append to the front
+            /*
+             * * Append to the front
              * Then do something else
              * Then do a third thing
              */
+            
             first = newNode;
         }
 
@@ -119,9 +128,11 @@ public class DoublyLinkedList<T> implements Iterable<T> {
         }
     }
 
-    /* ----------------------------------------------------------------------
+    /*
+     * ----------------------------------------------------------------------
      * HERE IS A LARGE FLOATING COMMENT
-     * ---------------------------------------------------------------------- */
+     * ---------------------------------------------------------------------- 
+     */
     private boolean removeIfLast() {
         /* Here is a small floating comment */
         if (isEmpty()) {
@@ -131,7 +142,8 @@ public class DoublyLinkedList<T> implements Iterable<T> {
         /* Decrement length */
         length--;
 
-        /* Reset first and last pointers if the list is now empty.
+        /*
+         * Reset first and last pointers if the list is now empty.
          * Return true if this is the case.
          */
         if (length == 0) {
@@ -141,8 +153,11 @@ public class DoublyLinkedList<T> implements Iterable<T> {
         }
 
         return false;
-    /*
-     * Return false only if there are remaining elements */
+        /*
+         * 
+         * Return false only if there are remaining elements 
+         */
+        
     }
 
     public boolean isEmpty() {
@@ -182,8 +197,10 @@ public class DoublyLinkedList<T> implements Iterable<T> {
             }
 
             @Override
-            /* This method overrides a method on Iterator
+            /*
+             * This method overrides a method on Iterator
              */
+            
             public void remove() {
                 /*
                  * We don't allow element removal via this iterator

--- a/tests/output/java8_block_comments
+++ b/tests/output/java8_block_comments
@@ -205,11 +205,14 @@ public class DoublyLinkedList<T> implements Iterable<T> {
          * 
          * Return false only if there are remaining elements 
          */
-        
     }
 
     public boolean isEmpty() {
         return first == null;
+        /*
+         * 
+         * Return true if there is no first element 
+         */
     }
 
     public LinkedListNode<T> getFirst() {

--- a/tests/output/java8_complex_guice
+++ b/tests/output/java8_complex_guice
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2008 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.inject.internal;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -20,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+/** @author jessewilson@google.com (Jesse Wilson) */
 final class InheritingState implements State {
     private final State parent;
 
@@ -32,8 +48,10 @@ final class InheritingState implements State {
 
     private final List<TypeConverterBinding> converters = Lists.newArrayList();
 
+    /*if[AOP]*/
     private final List<MethodAspect> methodAspects = Lists.newArrayList();
 
+    /*end[AOP]*/
     private final List<TypeListenerBinding> typeListenerBindings = Lists.newArrayList();
 
     private final List<ProvisionListenerBinding> provisionListenerBindings = Lists.newArrayList();
@@ -122,6 +140,7 @@ final class InheritingState implements State {
         return matchingConverter;
     }
 
+    /*if[AOP]*/
     @Override
     public void addMethodAspect(MethodAspect methodAspect) {
         methodAspects.add(methodAspect);
@@ -132,6 +151,7 @@ final class InheritingState implements State {
         return new ImmutableList.Builder<MethodAspect>().addAll(parent.getMethodAspects()).addAll(methodAspects).build();
     }
 
+    /*end[AOP]*/
     @Override
     public void addTypeListener(TypeListenerBinding listenerBinding) {
         typeListenerBindings.add(listenerBinding);

--- a/tests/output/java8_complex_guice
+++ b/tests/output/java8_complex_guice
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-/** @author jessewilson@google.com (Jesse Wilson) */
+/* * @author jessewilson@google.com (Jesse Wilson) */
 final class InheritingState implements State {
     private final State parent;
 
@@ -48,10 +48,10 @@ final class InheritingState implements State {
 
     private final List<TypeConverterBinding> converters = Lists.newArrayList();
 
-    /*if[AOP]*/
+    /* if[AOP]*/
     private final List<MethodAspect> methodAspects = Lists.newArrayList();
 
-    /*end[AOP]*/
+    /* end[AOP]*/
     private final List<TypeListenerBinding> typeListenerBindings = Lists.newArrayList();
 
     private final List<ProvisionListenerBinding> provisionListenerBindings = Lists.newArrayList();
@@ -140,7 +140,7 @@ final class InheritingState implements State {
         return matchingConverter;
     }
 
-    /*if[AOP]*/
+    /* if[AOP]*/
     @Override
     public void addMethodAspect(MethodAspect methodAspect) {
         methodAspects.add(methodAspect);
@@ -151,7 +151,7 @@ final class InheritingState implements State {
         return new ImmutableList.Builder<MethodAspect>().addAll(parent.getMethodAspects()).addAll(methodAspects).build();
     }
 
-    /*end[AOP]*/
+    /* end[AOP]*/
     @Override
     public void addTypeListener(TypeListenerBinding listenerBinding) {
         typeListenerBindings.add(listenerBinding);

--- a/tests/output/java8_complex_guice
+++ b/tests/output/java8_complex_guice
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.google.inject.internal;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -152,6 +153,7 @@ final class InheritingState implements State {
     }
 
     /* end[AOP]*/
+
     @Override
     public void addTypeListener(TypeListenerBinding listenerBinding) {
         typeListenerBindings.add(listenerBinding);

--- a/tests/output/java8_complex_spring
+++ b/tests/output/java8_complex_spring
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.core;
 
 import java.util.ArrayList;

--- a/tests/output/java8_complex_spring
+++ b/tests/output/java8_complex_spring
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.core;
 
 import java.util.ArrayList;
@@ -25,6 +40,17 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.ReflectionUtils;
 
+/**
+ * Factory for collections that is aware of Java 5, Java 6, and Spring collection types.
+ *
+ * <p>Mainly for internal use within the framework.
+ *
+ * @author Juergen Hoeller
+ * @author Arjen Poutsma
+ * @author Oliver Gierke
+ * @author Sam Brannen
+ * @since 1.1.1
+ */
 public final class CollectionFactory {
     private static final Set<Class<?>> approximableCollectionTypes = new HashSet<>();
 
@@ -56,10 +82,36 @@ public final class CollectionFactory {
     private CollectionFactory() {
     }
 
+    /**
+     * Determine whether the given collection type is an <em>approximable</em> type,
+     * i.e. a type that {@link #createApproximateCollection} can approximate.
+     * @param collectionType the collection type to check
+     * @return {@code true} if the type is <em>approximable</em>
+     */
     public static boolean isApproximableCollectionType(@Nullable Class<?> collectionType) {
         return (collectionType != null && approximableCollectionTypes.contains(collectionType));
     }
 
+    /**
+     * Create the most approximate collection for the given collection.
+     * <p><strong>Warning</strong>: Since the parameterized type {@code E} is
+     * not bound to the type of elements contained in the supplied
+     * {@code collection}, type safety cannot be guaranteed if the supplied
+     * {@code collection} is an {@link EnumSet}. In such scenarios, the caller
+     * is responsible for ensuring that the element type for the supplied
+     * {@code collection} is an enum type matching type {@code E}. As an
+     * alternative, the caller may wish to treat the return value as a raw
+     * collection or collection of {@link Object}.
+     * @param collection the original collection object, potentially {@code null}
+     * @param capacity the initial capacity
+     * @return a new, empty collection instance
+     * @see #isApproximableCollectionType
+     * @see java.util.LinkedList
+     * @see java.util.ArrayList
+     * @see java.util.EnumSet
+     * @see java.util.TreeSet
+     * @see java.util.LinkedHashSet
+     */
     @SuppressWarnings({"unchecked", "cast", "rawtypes"})
     public static <E> Collection<E> createApproximateCollection(@Nullable Object collection, int capacity) {
         if (collection instanceof LinkedList) {
@@ -78,6 +130,16 @@ public final class CollectionFactory {
         }
     }
 
+    /**
+     * Create the most appropriate collection for the given collection type.
+     * <p>Delegates to {@link #createCollection(Class, Class, int)} with a
+     * {@code null} element type.
+     * @param collectionType the desired type of the target collection; never {@code null}
+     * @param capacity the initial capacity
+     * @return a new collection instance
+     * @throws IllegalArgumentException if the supplied {@code collectionType}
+     * is {@code null} or of type {@link EnumSet}
+     */
     public static <E> Collection<E> createCollection(Class<?> collectionType, int capacity) {
         return createCollection(
             collectionType,
@@ -86,6 +148,29 @@ public final class CollectionFactory {
         );
     }
 
+    /**
+     * Create the most appropriate collection for the given collection type.
+     * <p><strong>Warning</strong>: Since the parameterized type {@code E} is
+     * not bound to the supplied {@code elementType}, type safety cannot be
+     * guaranteed if the desired {@code collectionType} is {@link EnumSet}.
+     * In such scenarios, the caller is responsible for ensuring that the
+     * supplied {@code elementType} is an enum type matching type {@code E}.
+     * As an alternative, the caller may wish to treat the return value as a
+     * raw collection or collection of {@link Object}.
+     * @param collectionType the desired type of the target collection; never {@code null}
+     * @param elementType the collection's element type, or {@code null} if unknown
+     * (note: only relevant for {@link EnumSet} creation)
+     * @param capacity the initial capacity
+     * @return a new collection instance
+     * @since 4.1.3
+     * @see java.util.LinkedHashSet
+     * @see java.util.ArrayList
+     * @see java.util.TreeSet
+     * @see java.util.EnumSet
+     * @throws IllegalArgumentException if the supplied {@code collectionType} is
+     * {@code null}; or if the desired {@code collectionType} is {@link EnumSet} and
+     * the supplied {@code elementType} is not a subtype of {@link Enum}
+     */
     @SuppressWarnings({"unchecked", "cast"})
     public static <E> Collection<E> createCollection(
         Class<?> collectionType,
@@ -121,10 +206,33 @@ public final class CollectionFactory {
         }
     }
 
+    /**
+     * Determine whether the given map type is an <em>approximable</em> type,
+     * i.e. a type that {@link #createApproximateMap} can approximate.
+     * @param mapType the map type to check
+     * @return {@code true} if the type is <em>approximable</em>
+     */
     public static boolean isApproximableMapType(@Nullable Class<?> mapType) {
         return (mapType != null && approximableMapTypes.contains(mapType));
     }
 
+    /**
+     * Create the most approximate map for the given map.
+     * <p><strong>Warning</strong>: Since the parameterized type {@code K} is
+     * not bound to the type of keys contained in the supplied {@code map},
+     * type safety cannot be guaranteed if the supplied {@code map} is an
+     * {@link EnumMap}. In such scenarios, the caller is responsible for
+     * ensuring that the key type in the supplied {@code map} is an enum type
+     * matching type {@code K}. As an alternative, the caller may wish to
+     * treat the return value as a raw map or map keyed by {@link Object}.
+     * @param map the original map object, potentially {@code null}
+     * @param capacity the initial capacity
+     * @return a new, empty map instance
+     * @see #isApproximableMapType
+     * @see java.util.EnumMap
+     * @see java.util.TreeMap
+     * @see java.util.LinkedHashMap
+     */
     @SuppressWarnings({"unchecked", "rawtypes"})
     public static <K, V> Map<K, V> createApproximateMap(@Nullable Object map, int capacity) {
         if (map instanceof EnumMap) {
@@ -138,6 +246,16 @@ public final class CollectionFactory {
         }
     }
 
+    /**
+     * Create the most appropriate map for the given map type.
+     * <p>Delegates to {@link #createMap(Class, Class, int)} with a
+     * {@code null} key type.
+     * @param mapType the desired type of the target map
+     * @param capacity the initial capacity
+     * @return a new map instance
+     * @throws IllegalArgumentException if the supplied {@code mapType} is
+     * {@code null} or of type {@link EnumMap}
+     */
     public static <K, V> Map<K, V> createMap(Class<?> mapType, int capacity) {
         return createMap(
             mapType,
@@ -146,6 +264,30 @@ public final class CollectionFactory {
         );
     }
 
+    /**
+     * Create the most appropriate map for the given map type.
+     * <p><strong>Warning</strong>: Since the parameterized type {@code K}
+     * is not bound to the supplied {@code keyType}, type safety cannot be
+     * guaranteed if the desired {@code mapType} is {@link EnumMap}. In such
+     * scenarios, the caller is responsible for ensuring that the {@code keyType}
+     * is an enum type matching type {@code K}. As an alternative, the caller
+     * may wish to treat the return value as a raw map or map keyed by
+     * {@link Object}. Similarly, type safety cannot be enforced if the
+     * desired {@code mapType} is {@link MultiValueMap}.
+     * @param mapType the desired type of the target map; never {@code null}
+     * @param keyType the map's key type, or {@code null} if unknown
+     * (note: only relevant for {@link EnumMap} creation)
+     * @param capacity the initial capacity
+     * @return a new map instance
+     * @since 4.1.3
+     * @see java.util.LinkedHashMap
+     * @see java.util.TreeMap
+     * @see org.springframework.util.LinkedMultiValueMap
+     * @see java.util.EnumMap
+     * @throws IllegalArgumentException if the supplied {@code mapType} is
+     * {@code null}; or if the desired {@code mapType} is {@link EnumMap} and
+     * the supplied {@code keyType} is not a subtype of {@link Enum}
+     */
     @SuppressWarnings({"unchecked", "rawtypes"})
     public static <K, V> Map<K, V> createMap(
         Class<?> mapType,
@@ -180,6 +322,12 @@ public final class CollectionFactory {
         }
     }
 
+    /**
+     * Create a variant of {@code java.util.Properties} that automatically adapts
+     * non-String values to String representations on {@link Properties#getProperty}.
+     * @return a new {@code Properties} instance
+     * @since 4.3.4
+     */
     @SuppressWarnings("serial")
     public static Properties createStringAdaptingProperties() {
         return new Properties() {
@@ -192,6 +340,12 @@ public final class CollectionFactory {
         };
     }
 
+    /**
+     * Cast the given type to a subtype of {@link Enum}.
+     * @param enumType the enum type, never {@code null}
+     * @return the given type as subtype of {@link Enum}
+     * @throws IllegalArgumentException if the given type is not a subtype of {@link Enum}
+     */
     @SuppressWarnings("rawtypes")
     private static Class<? extends Enum> asEnumType(Class<?> enumType) {
         Assert.notNull(enumType, "Enum type must not be null");

--- a/tests/output/java8_complex_spring
+++ b/tests/output/java8_complex_spring
@@ -40,7 +40,8 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.ReflectionUtils;
 
-/**
+/*
+ * *
  * Factory for collections that is aware of Java 5, Java 6, and Spring collection types.
  *
  * <p>Mainly for internal use within the framework.
@@ -82,7 +83,8 @@ public final class CollectionFactory {
     private CollectionFactory() {
     }
 
-    /**
+    /*
+     * *
      * Determine whether the given collection type is an <em>approximable</em> type,
      * i.e. a type that {@link #createApproximateCollection} can approximate.
      * @param collectionType the collection type to check
@@ -92,7 +94,8 @@ public final class CollectionFactory {
         return (collectionType != null && approximableCollectionTypes.contains(collectionType));
     }
 
-    /**
+    /*
+     * *
      * Create the most approximate collection for the given collection.
      * <p><strong>Warning</strong>: Since the parameterized type {@code E} is
      * not bound to the type of elements contained in the supplied
@@ -130,7 +133,8 @@ public final class CollectionFactory {
         }
     }
 
-    /**
+    /*
+     * *
      * Create the most appropriate collection for the given collection type.
      * <p>Delegates to {@link #createCollection(Class, Class, int)} with a
      * {@code null} element type.
@@ -148,7 +152,8 @@ public final class CollectionFactory {
         );
     }
 
-    /**
+    /*
+     * *
      * Create the most appropriate collection for the given collection type.
      * <p><strong>Warning</strong>: Since the parameterized type {@code E} is
      * not bound to the supplied {@code elementType}, type safety cannot be
@@ -206,7 +211,8 @@ public final class CollectionFactory {
         }
     }
 
-    /**
+    /*
+     * *
      * Determine whether the given map type is an <em>approximable</em> type,
      * i.e. a type that {@link #createApproximateMap} can approximate.
      * @param mapType the map type to check
@@ -216,7 +222,8 @@ public final class CollectionFactory {
         return (mapType != null && approximableMapTypes.contains(mapType));
     }
 
-    /**
+    /*
+     * *
      * Create the most approximate map for the given map.
      * <p><strong>Warning</strong>: Since the parameterized type {@code K} is
      * not bound to the type of keys contained in the supplied {@code map},
@@ -246,7 +253,8 @@ public final class CollectionFactory {
         }
     }
 
-    /**
+    /*
+     * *
      * Create the most appropriate map for the given map type.
      * <p>Delegates to {@link #createMap(Class, Class, int)} with a
      * {@code null} key type.
@@ -264,7 +272,8 @@ public final class CollectionFactory {
         );
     }
 
-    /**
+    /*
+     * *
      * Create the most appropriate map for the given map type.
      * <p><strong>Warning</strong>: Since the parameterized type {@code K}
      * is not bound to the supplied {@code keyType}, type safety cannot be
@@ -322,7 +331,8 @@ public final class CollectionFactory {
         }
     }
 
-    /**
+    /*
+     * *
      * Create a variant of {@code java.util.Properties} that automatically adapts
      * non-String values to String representations on {@link Properties#getProperty}.
      * @return a new {@code Properties} instance
@@ -340,7 +350,8 @@ public final class CollectionFactory {
         };
     }
 
-    /**
+    /*
+     * *
      * Cast the given type to a subtype of {@link Enum}.
      * @param enumType the enum type, never {@code null}
      * @return the given type as subtype of {@link Enum}

--- a/tests/output/java8_concepts
+++ b/tests/output/java8_concepts
@@ -1,6 +1,7 @@
 /*
  * NOTE: This file was retrieved from https://github.com/javaparser/javaparser under an Apache licence.
  */
+
 package japa.bdd.samples;
 
 import com.github.javaparser.JavaParser;

--- a/tests/output/java8_concepts
+++ b/tests/output/java8_concepts
@@ -1,3 +1,6 @@
+/*
+ * NOTE: This file was retrieved from https://github.com/javaparser/javaparser under an Apache licence.
+ */
 package japa.bdd.samples;
 
 import com.github.javaparser.JavaParser;

--- a/tests/output/java8_interface
+++ b/tests/output/java8_interface
@@ -1,5 +1,8 @@
 package com.konjex.util.provide;
 
+/**
+ * Object that can be provided by a provider.
+ */
 public interface Providable<MatchType> extends DataClass {
     MatchType getProviderKey();
 }

--- a/tests/output/java8_interface
+++ b/tests/output/java8_interface
@@ -1,6 +1,6 @@
 package com.konjex.util.provide;
 
-/**
+/*
  * Object that can be provided by a provider.
  */
 public interface Providable<MatchType> extends DataClass {

--- a/tests/output/java8_medium
+++ b/tests/output/java8_medium
@@ -3,6 +3,9 @@ package com.konjex.lens.conf;
 import java.io.File;
 import java.util.function.Consumer;
 
+/**
+ * Class for loading lens configuration files by name.
+ */
 public abstract class ConfigFileLoader {
     private static final String CMD_CONFIG_PATH = System.getProperty("user.home") + File.separator + ".lens" + File.separator;
 

--- a/tests/output/java8_medium
+++ b/tests/output/java8_medium
@@ -3,7 +3,7 @@ package com.konjex.lens.conf;
 import java.io.File;
 import java.util.function.Consumer;
 
-/**
+/*
  * Class for loading lens configuration files by name.
  */
 public abstract class ConfigFileLoader {

--- a/tests/scope.rs
+++ b/tests/scope.rs
@@ -78,6 +78,11 @@ fn test_java8_line_comments() {
 }
 
 #[test]
+fn test_java8_block_comments() {
+    test_fjr("java8_block_comments", "java8");
+}
+
+#[test]
 fn test_json_simple() {
     test_fjr("json_simple", "json");
 }

--- a/tests/spec/java8
+++ b/tests/spec/java8
@@ -355,8 +355,8 @@ inject right PREFIX_LBCOM `/* {}\n`
 inject left INLINE_BCOM_START `\n[prefix]/*\n[prefix] * {}`
 inject left INLINE_BCOM_SP_LINE `[prefix] {}`
 inject left INLINE_BCOM_NSP_LINE `[prefix] * {}`
-inject left INLINE_BCOM_SP_LINE_END `[prefix] {}\n[prefix] */\n[prefix]`
-inject left INLINE_BCOM_NSP_LINE_END `[prefix] * {}\n[prefix] */\n[prefix]`
+inject left INLINE_BCOM_SP_LINE_END `[prefix] {}\n[prefix] */`
+inject left INLINE_BCOM_NSP_LINE_END `[prefix] * {}\n[prefix] */`
 inject left INLINE_BCOM_END `[prefix] {}`
 
 # Prefix block comments

--- a/tests/spec/java8
+++ b/tests/spec/java8
@@ -344,7 +344,7 @@ inject left INLINE_BCOM_SP_LINE `[prefix] {}`
 inject left INLINE_BCOM_NSP_LINE `[prefix] * {}`
 inject left INLINE_BCOM_SP_LINE_END `[prefix] {}\n[prefix] */\n[prefix]`
 inject left INLINE_BCOM_NSP_LINE_END `[prefix] * {}\n[prefix] */\n[prefix]`
-inject left INLINE_BCOM_END `[prefix] {}\n[prefix]`
+inject left INLINE_BCOM_END `[prefix] {}`
 
 # Prefix block comments
 inject right PREFIX_BCOM_SL_START `/*\n[prefix] * {}`
@@ -716,7 +716,10 @@ grammar {
         | grouped_statements inline_isolated_block_statement `{}\n\n[prefix]{}\n`
         | inline_isolated_block_statement
         | grouped_statements
-        | PREFIX_LCOM PREFIX `{}`;
+        | PREFIX_LCOM PREFIX `{}`
+        | PREFIX_LBCOM `/* {}\n`
+        | lone_inline_bcom
+        | grouping_prefix_bcom;
 
     isolated_block_statement `{}\n`
         | class_dec
@@ -1141,4 +1144,45 @@ grammar {
     #
     # COMMENTS
     #
+
+    lone_inline_bcom
+        | INLINE_BCOM_START [inline_bcom_lines] inline_bcom_end `/*\n[prefix] {1}{2}`
+        | INLINE_BCOM_START [inline_bcom_lines] inline_bcom_end trailing_prefix_bcom_group `/*\n[prefix] {1}{3}`;
+
+    inline_bcom_lines
+        | inline_bcom_lines inline_bcom_line `{}{}[prefix] `
+        | inline_bcom_line `{}[prefix] `;
+    inline_bcom_line
+        | INLINE_BCOM_SP_LINE
+        | INLINE_BCOM_NSP_LINE `* {}`;
+
+    inline_bcom_end
+        | INLINE_BCOM_END
+        | INLINE_BCOM_SP_LINE_END
+        | INLINE_BCOM_NSP_LINE_END;
+
+    trailing_prefix_bcom_group
+        | PREFIX_BCOM_SL_START [prefix_bcom_lines] prefix_bcom_end `*\n[prefix] * {}[prefix] {}{}`
+        | PREFIX_BCOM_NL_START [prefix_bcom_lines] prefix_bcom_end `*\n[prefix] {1}{2}`;
+
+    grouping_prefix_bcom
+        | PREFIX_BCOM_SL_START [prefix_bcom_lines] prefix_bcom_end `/*\n[prefix] * {}[prefix] {}{}`
+        | PREFIX_BCOM_NL_START [prefix_bcom_lines] prefix_bcom_end `/*\n[prefix] {1}{2}`;
+
+    prefix_bcom_lines
+        | prefix_bcom_lines prefix_bcom_line `{}{}[prefix] `
+        | prefix_bcom_line `{}[prefix] `;
+    prefix_bcom_line
+        | PREFIX_BCOM_SP_LINE
+        | PREFIX_BCOM_NSP_LINE `* {}`
+        | PREFIX_BCOM_END `*\n`
+        | PREFIX_BCOM_SP_LINE_END `{}\n`
+        | PREFIX_BCOM_NSP_LINE_END `* {}\n`
+        | PREFIX_BCOM_SL_START `* {}`
+        | PREFIX_BCOM_NL_START;
+
+    prefix_bcom_end
+        | PREFIX_BCOM_END
+        | PREFIX_BCOM_SP_LINE_END
+        | PREFIX_BCOM_NSP_LINE_END `* {}\n[prefix] */`;
 }

--- a/tests/spec/java8
+++ b/tests/spec/java8
@@ -3,6 +3,7 @@ alphabet '<>=+-*/\\%(){}[],.;:#!?^$@&|"\'`~ \t\n\r_ABCDEFGHIJKLMNOPQRSTUVWXYZabc
 cdfa {
     start_empty_line
         '//' -> prefix_lcom
+        '/*' -> prefix_lbcom
         ' ' | '\t' | '\n' | '\r' -> ws
         _ ->> ^_ -> start_non_empty_line;
 
@@ -141,7 +142,7 @@ cdfa {
 
     slash   ^SLASH
         '/' -> inline_lcom_prefix
-        '*' -> bcom
+        '*' -> inline_lbcom
         '=' -> ^ASSN;
 
     and     ^AND
@@ -259,10 +260,15 @@ cdfa {
         '\n' -> fail
         _ -> inline_lcom;
 
-    bcom
+    inline_lbcom
         '\n' -> ^BCOM_START -> start_bcom_itl
-        '*/' -> ^INLINE_BCOM -> start_empty_line
-        _ -> bcom;
+        '*/' -> ^INLINE_LBCOM -> start_non_empty_line
+        _ -> inline_lbcom;
+
+    prefix_lbcom
+        '\n' -> ^BCOM_START -> start_bcom_itl
+        '*/' -> ^PREFIX_LBCOM -> start_non_empty_line
+        _ -> prefix_lbcom;
 
     prefixed_bcom_start
         '/' -> ^PREFIXED_BCOM_LINE_END -> start_empty_line
@@ -291,17 +297,18 @@ cdfa {
 # Line comments
 inject left INLINE_LCOM ` /* {} */`
 inject right PREFIX_LCOM
-inject right ISO_BREAK `\n[prefix]`
+inject left INLINE_LBCOM ` {}`
+inject right PREFIX_LBCOM `{}\n[prefix]`
 
 # Block comments
 inject right BCOM_START
-inject right INLINE_BCOM `{}\n[prefix]`
 inject right PREFIXED_BCOM_LINE `[prefix] {}`
 inject right NON_PREFIXED_BCOM_LINE `[prefix] * {}`
 inject right PREFIXED_BCOM_LINE_END `[prefix] {}\n[prefix]`
 inject right NON_PREFIXED_BCOM_LINE_END `[prefix] * {}\n[prefix]`
 
 # Misc injections
+inject right ISO_BREAK `\n[prefix]`
 inject right PREFIX `[prefix]`
 
 grammar {
@@ -1082,4 +1089,8 @@ grammar {
         | STAR
         | PCT
         | SLASH;
+
+    #
+    # COMMENTS
+    #
 }

--- a/tests/spec/java8
+++ b/tests/spec/java8
@@ -22,6 +22,16 @@ cdfa {
         ' ' | '\t' | '\r' | '\n' -> ws
         _ -> prefix_bcom_nsp;
 
+    start_after_bcom_pre
+        '\n' -> ^_ -> start_after_bcom_post
+        ' ' | '\t' | '\r' -> start_after_bcom_pre
+        _ ->> ^PREFIX -> start_empty_line;
+
+    start_after_bcom_post
+        '\n' -> ^ISO_BREAK -> start_empty_line
+        ' ' | '\t' | '\r' -> ^_
+        _ ->> ^PREFIX -> start_empty_line;
+
     start_non_empty_line
         '{' -> ^LBRACE
         '}' -> ^RBRACE
@@ -292,13 +302,16 @@ cdfa {
 
     inline_bcom_sp
         '\n' -> ^INLINE_BCOM_SP_LINE -> start_inline_bcom_itl
-        '*/' ->> ^INLINE_BCOM_SP_LINE_END -> bcom_end_consumer
+        '*/' ->> ^INLINE_BCOM_SP_LINE_END -> inline_bcom_end_consumer
         _ -> inline_bcom_sp;
 
     inline_bcom_nsp
         '\n' -> ^INLINE_BCOM_NSP_LINE -> start_inline_bcom_itl
-        '*/' ->> ^INLINE_BCOM_NSP_LINE_END -> bcom_end_consumer
+        '*/' ->> ^INLINE_BCOM_NSP_LINE_END -> inline_bcom_end_consumer
         _ -> inline_bcom_nsp;
+
+    inline_bcom_end_consumer
+        '*/' -> ^_ -> start_empty_line;
 
     prefix_lbcom_prefix ^_ -> prefix_lbcom_nnl
         ' ' | '\t' -> prefix_lbcom_prefix;
@@ -309,25 +322,25 @@ cdfa {
 
     prefix_lbcom
         '\n' -> ^PREFIX_BCOM_SL_START -> start_prefix_bcom_itl
-        '*/' -> ^PREFIX_LBCOM -> start_empty_line
+        '*/' -> ^PREFIX_LBCOM -> start_after_bcom_pre
         _ -> prefix_lbcom;
 
     prefix_bcom_sp_start
-        '/' -> ^PREFIX_BCOM_END -> start_empty_line
+        '/' -> ^PREFIX_BCOM_END -> start_after_bcom_pre
         _ ->> prefix_bcom_sp;
 
     prefix_bcom_sp
         '\n' -> ^PREFIX_BCOM_SP_LINE -> start_prefix_bcom_itl
-        '*/' ->> ^PREFIX_BCOM_SP_LINE_END -> bcom_end_consumer
+        '*/' ->> ^PREFIX_BCOM_SP_LINE_END -> prefix_bcom_end_consumer
         _ -> prefix_bcom_sp;
 
     prefix_bcom_nsp
         '\n' -> ^PREFIX_BCOM_NSP_LINE -> start_prefix_bcom_itl
-        '*/' ->> ^PREFIX_BCOM_NSP_LINE_END -> bcom_end_consumer
+        '*/' ->> ^PREFIX_BCOM_NSP_LINE_END -> prefix_bcom_end_consumer
         _ -> prefix_bcom_nsp;
 
-    bcom_end_consumer
-        '*/' -> ^_ -> start_empty_line;
+    prefix_bcom_end_consumer
+        '*/' -> ^_ -> start_after_bcom_pre;
 }
 
 # Inline line comments
@@ -336,7 +349,7 @@ inject left INLINE_LBCOM ` /* {}`
 
 # Prefix line comments
 inject right PREFIX_LCOM
-inject right PREFIX_LBCOM `/* {}\n[prefix]`
+inject right PREFIX_LBCOM `/* {}\n`
 
 # Inline block comments
 inject left INLINE_BCOM_START `\n[prefix]/*\n[prefix] * {}`
@@ -351,9 +364,9 @@ inject right PREFIX_BCOM_SL_START `/*\n[prefix] * {}`
 inject right PREFIX_BCOM_NL_START `/*\n`
 inject right PREFIX_BCOM_SP_LINE `[prefix] {}`
 inject right PREFIX_BCOM_NSP_LINE `[prefix] * {}`
-inject right PREFIX_BCOM_SP_LINE_END `[prefix] {}\n[prefix] */\n[prefix]`
-inject right PREFIX_BCOM_NSP_LINE_END `[prefix] * {}\n[prefix] */\n[prefix]`
-inject right PREFIX_BCOM_END `[prefix] {}\n[prefix]`
+inject right PREFIX_BCOM_SP_LINE_END `[prefix] {}\n[prefix] */\n`
+inject right PREFIX_BCOM_NSP_LINE_END `[prefix] * {}\n[prefix] */\n`
+inject right PREFIX_BCOM_END `[prefix] {}\n`
 
 # Misc injections
 inject right ISO_BREAK `\n[prefix]`
@@ -717,7 +730,7 @@ grammar {
         | inline_isolated_block_statement
         | grouped_statements
         | PREFIX_LCOM PREFIX `{}`
-        | PREFIX_LBCOM `/* {}\n`
+        | PREFIX_LBCOM [PREFIX] [ISO_BREAK] `/* {}\n`
         | lone_inline_bcom
         | grouping_prefix_bcom;
 
@@ -1175,14 +1188,14 @@ grammar {
     prefix_bcom_line
         | PREFIX_BCOM_SP_LINE
         | PREFIX_BCOM_NSP_LINE `* {}`
-        | PREFIX_BCOM_END `*\n`
-        | PREFIX_BCOM_SP_LINE_END `{}\n`
-        | PREFIX_BCOM_NSP_LINE_END `* {}\n`
+        | PREFIX_BCOM_END [PREFIX] [ISO_BREAK] `*\n`
+        | PREFIX_BCOM_SP_LINE_END [PREFIX] [ISO_BREAK] `{}\n`
+        | PREFIX_BCOM_NSP_LINE_END [PREFIX] [ISO_BREAK] `* {}\n`
         | PREFIX_BCOM_SL_START `* {}`
         | PREFIX_BCOM_NL_START;
 
-    prefix_bcom_end
-        | PREFIX_BCOM_END
-        | PREFIX_BCOM_SP_LINE_END
-        | PREFIX_BCOM_NSP_LINE_END `* {}\n[prefix] */`;
+    prefix_bcom_end `{}`
+        | PREFIX_BCOM_END [PREFIX] [ISO_BREAK]
+        | PREFIX_BCOM_SP_LINE_END [PREFIX] [ISO_BREAK]
+        | PREFIX_BCOM_NSP_LINE_END [PREFIX] [ISO_BREAK] `* {}\n[prefix] */`;
 }

--- a/tests/spec/java8
+++ b/tests/spec/java8
@@ -3,7 +3,7 @@ alphabet '<>=+-*/\\%(){}[],.;:#!?^$@&|"\'`~ \t\n\r_ABCDEFGHIJKLMNOPQRSTUVWXYZabc
 cdfa {
     start_empty_line
         '//' -> prefix_lcom
-        '/*' -> prefix_lbcom
+        '/*' -> prefix_lbcom_prefix
         ' ' | '\t' | '\n' | '\r' -> ws
         _ ->> ^_ -> start_non_empty_line;
 
@@ -12,10 +12,15 @@ cdfa {
         ' ' | '\t' | '\r' -> ^_
         _ ->> ^PREFIX -> start_empty_line;
 
-    start_bcom_itl
-        '*' -> prefixed_bcom_start
+    start_inline_bcom_itl
+        '*' -> inline_bcom_sp_start
         ' ' | '\t' | '\r' | '\n' -> ws
-        _ -> non_prefixed_bcom;
+        _ -> inline_bcom_nsp;
+
+    start_prefix_bcom_itl
+        '*' -> prefix_bcom_sp_start
+        ' ' | '\t' | '\r' | '\n' -> ws
+        _ -> prefix_bcom_nsp;
 
     start_non_empty_line
         '{' -> ^LBRACE
@@ -142,7 +147,7 @@ cdfa {
 
     slash   ^SLASH
         '/' -> inline_lcom_prefix
-        '*' -> inline_lbcom
+        '*' -> inline_lbcom_prefix
         '=' -> ^ASSN;
 
     and     ^AND
@@ -249,41 +254,6 @@ cdfa {
     ws      ^_
         ' ' | '\t' | '\n' | '\r' -> ws;
 
-    prefix_lcom ^PREFIX_LCOM -> start_after_prefix_lcom
-        '\n' -> ^PREFIX_LCOM -> start_after_prefix_lcom
-        _ -> prefix_lcom;
-
-    inline_lcom_prefix ^_ -> inline_lcom
-        ' ' | '\t' -> inline_lcom_prefix;
-
-    inline_lcom ^INLINE_LCOM -> start_non_empty_line
-        '\n' -> fail
-        _ -> inline_lcom;
-
-    inline_lbcom
-        '\n' -> ^BCOM_START -> start_bcom_itl
-        '*/' -> ^INLINE_LBCOM -> start_non_empty_line
-        _ -> inline_lbcom;
-
-    prefix_lbcom
-        '\n' -> ^BCOM_START -> start_bcom_itl
-        '*/' -> ^PREFIX_LBCOM -> start_non_empty_line
-        _ -> prefix_lbcom;
-
-    prefixed_bcom_start
-        '/' -> ^PREFIXED_BCOM_LINE_END -> start_empty_line
-        _ ->> prefixed_bcom;
-
-    prefixed_bcom
-        '\n' -> ^PREFIXED_BCOM_LINE -> start_bcom_itl
-        '*/' -> ^PREFIXED_BCOM_LINE_END -> start_empty_line
-        _ -> prefixed_bcom;
-
-    non_prefixed_bcom
-        '\n' -> ^NON_PREFIXED_BCOM_LINE -> start_bcom_itl
-        '*/' -> ^NON_PREFIXED_BCOM_LINE_END -> start_empty_line
-        _ -> non_prefixed_bcom;
-
     MOD | ASSERT | PRIM | BREAK | CASE | CATCH | ENUM | CLASS | CONTINUE | DEFAULT | DO | ELSE | EXTENDS | FINALLY | FOR
         | IF | IMPLEMENTS | IMPORT | INSTANCEOF | NEW | PACKAGE | RETURN | SUPER | SWITCH | THIS | THROWS | TRY | VOID
         | WHILE | INTERFACE | SYNCHRONIZED | STATIC
@@ -292,20 +262,93 @@ cdfa {
 
     id      ^ID
         '_' .. '9' | '$' -> id;
+
+    #
+    # COMMENTS
+    #
+
+    prefix_lcom ^PREFIX_LCOM -> start_after_prefix_lcom
+        '\n' -> ^PREFIX_LCOM -> start_after_prefix_lcom
+        _ -> prefix_lcom;
+
+    inline_lcom_prefix ^_ -> inline_lcom
+        ' ' | '\t' -> inline_lcom_prefix;
+
+    inline_lcom ^INLINE_LCOM -> start_empty_line
+        '\n' -> fail
+        _ -> inline_lcom;
+
+    inline_lbcom_prefix ^_ -> inline_lbcom
+        ' ' | '\t' -> inline_lbcom_prefix;
+
+    inline_lbcom
+        '\n' -> ^INLINE_BCOM_START -> start_inline_bcom_itl
+        '*/' -> ^INLINE_LBCOM -> start_empty_line
+        _ -> inline_lbcom;
+
+    inline_bcom_sp_start
+        '/' -> ^INLINE_BCOM_SP_LINE_END -> start_empty_line
+        _ ->> inline_bcom_sp;
+
+    inline_bcom_sp
+        '\n' -> ^INLINE_BCOM_SP_LINE -> start_inline_bcom_itl
+        '*/' -> ^INLINE_BCOM_SP_LINE_END -> start_empty_line
+        _ -> inline_bcom_sp;
+
+    inline_bcom_nsp
+        '\n' -> ^INLINE_BCOM_NSP_LINE -> start_inline_bcom_itl
+        '*/' -> ^INLINE_BCOM_NSP_LINE_END -> start_empty_line
+        _ -> inline_bcom_nsp;
+
+    prefix_lbcom_prefix ^_ -> prefix_lbcom_nnl
+        ' ' | '\t' -> prefix_lbcom_prefix;
+
+    prefix_lbcom_nnl
+            '\n' -> ^PREFIX_BCOM_NL_START -> start_prefix_bcom_itl
+            _ ->> prefix_lbcom;
+
+    prefix_lbcom
+        '\n' -> ^PREFIX_BCOM_SL_START -> start_prefix_bcom_itl
+        '*/' -> ^PREFIX_LBCOM -> start_empty_line
+        _ -> prefix_lbcom;
+
+    prefix_bcom_sp_start
+        '/' -> ^PREFIX_BCOM_SP_LINE_END -> start_empty_line
+        _ ->> prefix_bcom_sp;
+
+    prefix_bcom_sp
+        '\n' -> ^PREFIX_BCOM_SP_LINE -> start_prefix_bcom_itl
+        '*/' -> ^PREFIX_BCOM_SP_LINE_END -> start_empty_line
+        _ -> prefix_bcom_sp;
+
+    prefix_bcom_nsp
+        '\n' -> ^PREFIX_BCOM_NSP_LINE -> start_prefix_bcom_itl
+        '*/' -> ^PREFIX_BCOM_NSP_LINE_END -> start_empty_line
+        _ -> prefix_bcom_nsp;
 }
 
-# Line comments
+# Inline line comments
 inject left INLINE_LCOM ` /* {} */`
-inject right PREFIX_LCOM
-inject left INLINE_LBCOM ` {}`
-inject right PREFIX_LBCOM `{}\n[prefix]`
+inject left INLINE_LBCOM ` /* {}`
 
-# Block comments
-inject right BCOM_START
-inject right PREFIXED_BCOM_LINE `[prefix] {}`
-inject right NON_PREFIXED_BCOM_LINE `[prefix] * {}`
-inject right PREFIXED_BCOM_LINE_END `[prefix] {}\n[prefix]`
-inject right NON_PREFIXED_BCOM_LINE_END `[prefix] * {}\n[prefix]`
+# Prefix line comments
+inject right PREFIX_LCOM
+inject right PREFIX_LBCOM `/* {}\n[prefix]`
+
+# Inline block comments
+inject left INLINE_BCOM_START `\n[prefix]/*\n[prefix] * {}`
+inject left INLINE_BCOM_SP_LINE `[prefix] {}`
+inject left INLINE_BCOM_NSP_LINE `[prefix] * {}`
+inject left INLINE_BCOM_SP_LINE_END `[prefix] {}\n[prefix]`
+inject left INLINE_BCOM_NSP_LINE_END `[prefix] * {}\n[prefix]`
+
+# Prefix block comments
+inject right PREFIX_BCOM_SL_START `/*\n[prefix] * {}`
+inject right PREFIX_BCOM_NL_START `/*\n`
+inject right PREFIX_BCOM_SP_LINE `[prefix] {}`
+inject right PREFIX_BCOM_NSP_LINE `[prefix] * {}`
+inject right PREFIX_BCOM_SP_LINE_END `[prefix] {}\n[prefix]`
+inject right PREFIX_BCOM_NSP_LINE_END `[prefix] * {}\n[prefix]`
 
 # Misc injections
 inject right ISO_BREAK `\n[prefix]`

--- a/tests/spec/java8
+++ b/tests/spec/java8
@@ -287,17 +287,17 @@ cdfa {
         _ -> inline_lbcom;
 
     inline_bcom_sp_start
-        '/' -> ^INLINE_BCOM_SP_LINE_END -> start_empty_line
+        '/' -> ^INLINE_BCOM_END -> start_empty_line
         _ ->> inline_bcom_sp;
 
     inline_bcom_sp
         '\n' -> ^INLINE_BCOM_SP_LINE -> start_inline_bcom_itl
-        '*/' -> ^INLINE_BCOM_SP_LINE_END -> start_empty_line
+        '*/' ->> ^INLINE_BCOM_SP_LINE_END -> bcom_end_consumer
         _ -> inline_bcom_sp;
 
     inline_bcom_nsp
         '\n' -> ^INLINE_BCOM_NSP_LINE -> start_inline_bcom_itl
-        '*/' -> ^INLINE_BCOM_NSP_LINE_END -> start_empty_line
+        '*/' ->> ^INLINE_BCOM_NSP_LINE_END -> bcom_end_consumer
         _ -> inline_bcom_nsp;
 
     prefix_lbcom_prefix ^_ -> prefix_lbcom_nnl
@@ -313,18 +313,21 @@ cdfa {
         _ -> prefix_lbcom;
 
     prefix_bcom_sp_start
-        '/' -> ^PREFIX_BCOM_SP_LINE_END -> start_empty_line
+        '/' -> ^PREFIX_BCOM_END -> start_empty_line
         _ ->> prefix_bcom_sp;
 
     prefix_bcom_sp
         '\n' -> ^PREFIX_BCOM_SP_LINE -> start_prefix_bcom_itl
-        '*/' -> ^PREFIX_BCOM_SP_LINE_END -> start_empty_line
+        '*/' ->> ^PREFIX_BCOM_SP_LINE_END -> bcom_end_consumer
         _ -> prefix_bcom_sp;
 
     prefix_bcom_nsp
         '\n' -> ^PREFIX_BCOM_NSP_LINE -> start_prefix_bcom_itl
-        '*/' -> ^PREFIX_BCOM_NSP_LINE_END -> start_empty_line
+        '*/' ->> ^PREFIX_BCOM_NSP_LINE_END -> bcom_end_consumer
         _ -> prefix_bcom_nsp;
+
+    bcom_end_consumer
+        '*/' -> ^_ -> start_empty_line;
 }
 
 # Inline line comments
@@ -339,16 +342,18 @@ inject right PREFIX_LBCOM `/* {}\n[prefix]`
 inject left INLINE_BCOM_START `\n[prefix]/*\n[prefix] * {}`
 inject left INLINE_BCOM_SP_LINE `[prefix] {}`
 inject left INLINE_BCOM_NSP_LINE `[prefix] * {}`
-inject left INLINE_BCOM_SP_LINE_END `[prefix] {}\n[prefix]`
-inject left INLINE_BCOM_NSP_LINE_END `[prefix] * {}\n[prefix]`
+inject left INLINE_BCOM_SP_LINE_END `[prefix] {}\n[prefix] */\n[prefix]`
+inject left INLINE_BCOM_NSP_LINE_END `[prefix] * {}\n[prefix] */\n[prefix]`
+inject left INLINE_BCOM_END `[prefix] {}\n[prefix]`
 
 # Prefix block comments
 inject right PREFIX_BCOM_SL_START `/*\n[prefix] * {}`
 inject right PREFIX_BCOM_NL_START `/*\n`
 inject right PREFIX_BCOM_SP_LINE `[prefix] {}`
 inject right PREFIX_BCOM_NSP_LINE `[prefix] * {}`
-inject right PREFIX_BCOM_SP_LINE_END `[prefix] {}\n[prefix]`
-inject right PREFIX_BCOM_NSP_LINE_END `[prefix] * {}\n[prefix]`
+inject right PREFIX_BCOM_SP_LINE_END `[prefix] {}\n[prefix] */\n[prefix]`
+inject right PREFIX_BCOM_NSP_LINE_END `[prefix] * {}\n[prefix] */\n[prefix]`
+inject right PREFIX_BCOM_END `[prefix] {}\n[prefix]`
 
 # Misc injections
 inject right ISO_BREAK `\n[prefix]`

--- a/tests/spec/java8
+++ b/tests/spec/java8
@@ -1183,16 +1183,16 @@ grammar {
         | PREFIX_BCOM_NL_START [prefix_bcom_lines] prefix_bcom_end `/*\n[prefix] {1}{2}`;
 
     prefix_bcom_lines
-        | prefix_bcom_lines prefix_bcom_line `{}{}[prefix] `
-        | prefix_bcom_line `{}[prefix] `;
+        | prefix_bcom_lines prefix_bcom_line
+        | prefix_bcom_line;
     prefix_bcom_line
-        | PREFIX_BCOM_SP_LINE
-        | PREFIX_BCOM_NSP_LINE `* {}`
-        | PREFIX_BCOM_END [PREFIX] [ISO_BREAK] `*\n`
-        | PREFIX_BCOM_SP_LINE_END [PREFIX] [ISO_BREAK] `{}\n`
-        | PREFIX_BCOM_NSP_LINE_END [PREFIX] [ISO_BREAK] `* {}\n`
-        | PREFIX_BCOM_SL_START `* {}`
-        | PREFIX_BCOM_NL_START;
+        | PREFIX_BCOM_SP_LINE `{}[prefix] `
+        | PREFIX_BCOM_NSP_LINE `* {}[prefix] `
+        | PREFIX_BCOM_END [PREFIX] [ISO_BREAK] `*\n[prefix] `
+        | PREFIX_BCOM_SP_LINE_END [PREFIX] [ISO_BREAK] `{}\n[prefix] `
+        | PREFIX_BCOM_NSP_LINE_END [PREFIX] [ISO_BREAK] `* {}\n[prefix] `
+        | PREFIX_BCOM_SL_START `* {}[prefix] `
+        | PREFIX_BCOM_NL_START ``;
 
     prefix_bcom_end `{}`
         | PREFIX_BCOM_END [PREFIX] [ISO_BREAK]

--- a/tests/spec/java8
+++ b/tests/spec/java8
@@ -11,6 +11,11 @@ cdfa {
         ' ' | '\t' | '\r' -> ^_
         _ ->> ^PREFIX -> start_empty_line;
 
+    start_bcom_itl
+        '*' -> prefixed_bcom_start
+        ' ' | '\t' | '\r' | '\n' -> ws
+        _ -> non_prefixed_bcom;
+
     start_non_empty_line
         '{' -> ^LBRACE
         '}' -> ^RBRACE
@@ -255,8 +260,23 @@ cdfa {
         _ -> inline_lcom;
 
     bcom
-        '*/' -> ^_
+        '\n' -> ^BCOM_START -> start_bcom_itl
+        '*/' -> ^INLINE_BCOM -> start_empty_line
         _ -> bcom;
+
+    prefixed_bcom_start
+        '/' -> ^PREFIXED_BCOM_LINE_END -> start_empty_line
+        _ ->> prefixed_bcom;
+
+    prefixed_bcom
+        '\n' -> ^PREFIXED_BCOM_LINE -> start_bcom_itl
+        '*/' -> ^PREFIXED_BCOM_LINE_END -> start_empty_line
+        _ -> prefixed_bcom;
+
+    non_prefixed_bcom
+        '\n' -> ^NON_PREFIXED_BCOM_LINE -> start_bcom_itl
+        '*/' -> ^NON_PREFIXED_BCOM_LINE_END -> start_empty_line
+        _ -> non_prefixed_bcom;
 
     MOD | ASSERT | PRIM | BREAK | CASE | CATCH | ENUM | CLASS | CONTINUE | DEFAULT | DO | ELSE | EXTENDS | FINALLY | FOR
         | IF | IMPLEMENTS | IMPORT | INSTANCEOF | NEW | PACKAGE | RETURN | SUPER | SWITCH | THIS | THROWS | TRY | VOID
@@ -268,9 +288,20 @@ cdfa {
         '_' .. '9' | '$' -> id;
 }
 
+# Line comments
 inject left INLINE_LCOM ` /* {} */`
 inject right PREFIX_LCOM
 inject right ISO_BREAK `\n[prefix]`
+
+# Block comments
+inject right BCOM_START
+inject right INLINE_BCOM `{}\n[prefix]`
+inject right PREFIXED_BCOM_LINE `[prefix] {}`
+inject right NON_PREFIXED_BCOM_LINE `[prefix] * {}`
+inject right PREFIXED_BCOM_LINE_END `[prefix] {}\n[prefix]`
+inject right NON_PREFIXED_BCOM_LINE_END `[prefix] * {}\n[prefix]`
+
+# Misc injections
 inject right PREFIX `[prefix]`
 
 grammar {


### PR DESCRIPTION
Add formatting rules for block comments to the java8 spec. This base implementation will carry over easily to other languages.

This pr contributes to #11 and is effectively the second half of #34.