### PR TITLE
Cli test tempfile and tempdir RAII improvements

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -89,22 +89,63 @@ mod tests {
         };
     }
 
+    struct TestDir {
+        path_buf: PathBuf,
+        path_str: String,
+        released: bool,
+    }
+
+    impl TestDir {
+        fn new() -> Self {
+            let path_str = format!("tests/temp-{}", Uuid::new_v4().to_string());
+            let path_buf = PathBuf::from(&path_str);
+            fs::create_dir(path_buf.as_path()).unwrap();
+
+            TestDir {
+                path_buf,
+                path_str,
+                released: false,
+            }
+        }
+
+        fn path(&self) -> &Path {
+            self.path_buf.as_path()
+        }
+
+        fn path_str(&self) -> &str {
+            &self.path_str
+        }
+
+        fn release(&mut self) {
+            self.released = true;
+            fs::remove_dir_all(self.path()).unwrap();
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            if !self.released {
+                self.release();
+            }
+        }
+    }
+
     struct TestableFile<'scope> {
         file_name: String,
-        temp_dir: &'scope Path,
+        dir: &'scope Path,
     }
 
     impl<'scope> TestableFile<'scope> {
-        fn new(file_name: String, temp_dir: &'scope str) -> Self {
+        fn new(file_name: String, test_dir: &'scope TestDir) -> Self {
             TestableFile {
                 file_name,
-                temp_dir: Path::new(temp_dir),
+                dir: test_dir.path(),
             }
         }
 
         fn copy_to_temp(&self) -> String {
             let input_path = path_from_name(&INPUT_DIR, &self.file_name);
-            let temp_path = path_from_name(self.temp_dir, &self.file_name);
+            let temp_path = path_from_name(self.dir, &self.file_name);
 
             fs::copy(input_path, &temp_path).unwrap();
 
@@ -113,7 +154,7 @@ mod tests {
 
         fn assert_matches_output(&self) {
             let output_path = path_from_name(&OUTPUT_DIR, &self.file_name);
-            let temp_path = path_from_name(self.temp_dir, &self.file_name);
+            let temp_path = path_from_name(self.dir, &self.file_name);
 
             let expected = read_to_string(output_path.as_path());
             let actual = read_to_string(temp_path.as_path());
@@ -125,7 +166,7 @@ mod tests {
 
         fn assert_does_not_match_output(&self) {
             let output_path = path_from_name(&OUTPUT_DIR, &self.file_name);
-            let temp_path = path_from_name(self.temp_dir, &self.file_name);
+            let temp_path = path_from_name(self.dir, &self.file_name);
 
             let expected = read_to_string(output_path.as_path());
             let actual = read_to_string(temp_path.as_path());
@@ -202,10 +243,10 @@ mod tests {
     #[test]
     fn test_fmt_all_java8() {
         //setup
-        let temp_dir = create_temp_dir();
+        let test_dir = TestDir::new();
 
         for file_name in files_with_prefix("java8") {
-            let file = TestableFile::new(file_name, &temp_dir);
+            let file = TestableFile::new(file_name, &test_dir);
             let temp_file = file.copy_to_temp();
 
             //exercise
@@ -222,27 +263,30 @@ mod tests {
             //verify
             file.assert_matches_output();
         }
-
-        //teardown
-        fs::remove_dir_all(&temp_dir).unwrap();
     }
 
     #[test]
     fn test_format_directory() {
         //setup
-        let temp_dir = create_temp_dir();
+        let test_dir = TestDir::new();
 
         let mut testable_files: Vec<TestableFile> = Vec::new();
 
         for file_name in files_with_prefix("json") {
-            let file = TestableFile::new(file_name, &temp_dir);
+            let file = TestableFile::new(file_name, &test_dir);
             file.copy_to_temp();
             testable_files.push(file);
         }
 
         //exercise
         parallel!({
-            cli::run(vec![EXECUTABLE, "fmt", "tests/spec/json", "-t", &temp_dir]);
+            cli::run(vec![
+                EXECUTABLE,
+                "fmt",
+                "tests/spec/json",
+                "-t",
+                test_dir.path_str(),
+            ]);
         });
 
         //verify
@@ -250,9 +294,6 @@ mod tests {
         for file in testable_files {
             file.assert_matches_output();
         }
-
-        //teardown
-        fs::remove_dir_all(&temp_dir).unwrap();
     }
 
     #[test]
@@ -290,12 +331,12 @@ mod tests {
     #[test]
     fn test_many_threads() {
         //setup
-        let temp_dir = create_temp_dir();
+        let test_dir = TestDir::new();
 
         let mut testable_files: Vec<TestableFile> = Vec::new();
 
         for file_name in files_with_prefix("java8") {
-            let file = TestableFile::new(file_name, &temp_dir);
+            let file = TestableFile::new(file_name, &test_dir);
             file.copy_to_temp();
             testable_files.push(file);
         }
@@ -307,7 +348,7 @@ mod tests {
                 "fmt",
                 "tests/spec/java8",
                 "-t",
-                &temp_dir,
+                test_dir.path_str(),
                 "--threads",
                 "16",
             ]);
@@ -318,20 +359,17 @@ mod tests {
         for file in testable_files {
             file.assert_matches_output();
         }
-
-        //teardown
-        fs::remove_dir_all(&temp_dir).unwrap();
     }
 
     #[test]
     fn test_invalid_threads_zero() {
         //setup
-        let temp_dir = create_temp_dir();
+        let test_dir = TestDir::new();
 
         let mut testable_files: Vec<TestableFile> = Vec::new();
 
         for file_name in files_with_prefix("json") {
-            let file = TestableFile::new(file_name, &temp_dir);
+            let file = TestableFile::new(file_name, &test_dir);
             file.copy_to_temp();
             testable_files.push(file);
         }
@@ -343,7 +381,7 @@ mod tests {
                 "fmt",
                 "tests/spec/json",
                 "-t",
-                &temp_dir,
+                test_dir.path_str(),
                 "--threads",
                 "0",
             ]);
@@ -354,20 +392,17 @@ mod tests {
         for file in testable_files {
             file.assert_matches_output();
         }
-
-        //teardown
-        fs::remove_dir_all(&temp_dir).unwrap();
     }
 
     #[test]
     fn test_invalid_threads_character() {
         //setup
-        let temp_dir = create_temp_dir();
+        let test_dir = TestDir::new();
 
         let mut testable_files: Vec<TestableFile> = Vec::new();
 
         for file_name in files_with_prefix("json") {
-            let file = TestableFile::new(file_name, &temp_dir);
+            let file = TestableFile::new(file_name, &test_dir);
             file.copy_to_temp();
             testable_files.push(file);
         }
@@ -379,7 +414,7 @@ mod tests {
                 "fmt",
                 "tests/spec/json",
                 "-t",
-                &temp_dir,
+                test_dir.path_str(),
                 "--threads",
                 "a",
             ]);
@@ -390,20 +425,17 @@ mod tests {
         for file in testable_files {
             file.assert_matches_output();
         }
-
-        //teardown
-        fs::remove_dir_all(&temp_dir).unwrap();
     }
 
     #[test]
     fn test_file_regex() {
         //setup
-        let temp_dir = create_temp_dir();
+        let test_dir = TestDir::new();
 
         let mut testable_files: Vec<TestableFile> = Vec::new();
 
         for file_name in files_with_prefix("") {
-            let file = TestableFile::new(file_name, &temp_dir);
+            let file = TestableFile::new(file_name, &test_dir);
             file.copy_to_temp();
             testable_files.push(file);
         }
@@ -415,7 +447,7 @@ mod tests {
                 "fmt",
                 "tests/spec/lacs",
                 "-t",
-                &temp_dir,
+                test_dir.path_str(),
                 "-m",
                 "lacs_.*",
             ]);
@@ -432,17 +464,14 @@ mod tests {
         }
 
         assert_eq!(formatted, 3);
-
-        //teardown
-        fs::remove_dir_all(&temp_dir).unwrap();
     }
 
     #[test]
     fn test_diff_tracking_unchanged() {
         //setup
-        let temp_dir = create_temp_dir();
+        let test_dir = TestDir::new();
 
-        let file = TestableFile::new("json_simple".to_string(), &temp_dir);
+        let file = TestableFile::new("json_simple".to_string(), &test_dir);
         let temp_path = file.copy_to_temp();
 
         parallel!({
@@ -457,17 +486,14 @@ mod tests {
         });
 
         file.assert_matches_output();
-
-        //teardown
-        fs::remove_dir_all(&temp_dir).unwrap();
     }
 
     #[test]
     fn test_diff_tracking_file_modified() {
         //setup
-        let temp_dir = create_temp_dir();
+        let test_dir = TestDir::new();
 
-        let file = TestableFile::new("json_simple".to_string(), &temp_dir);
+        let file = TestableFile::new("json_simple".to_string(), &test_dir);
         let temp_path = file.copy_to_temp();
 
         parallel!({
@@ -487,17 +513,14 @@ mod tests {
 
         let result = fs::read_to_string(&temp_path).unwrap();
         assert_eq!(result, "{\n    \"modified\": \"value\"\n}\n");
-
-        //teardown
-        fs::remove_dir_all(&temp_dir).unwrap();
     }
 
     #[test]
     fn test_diff_tracking_spec_modified() {
         //setup
-        let temp_dir = create_temp_dir();
+        let test_dir = TestDir::new();
 
-        let file = TestableFile::new("json_simple".to_string(), &temp_dir);
+        let file = TestableFile::new("json_simple".to_string(), &test_dir);
         let temp_path = file.copy_to_temp();
 
         parallel!({
@@ -507,7 +530,7 @@ mod tests {
         // Sleep to allow for SystemTime fluctuations
         thread::sleep(Duration::from_millis(10));
 
-        let new_spec_path = path_from_name(Path::new(&temp_dir), "spec");
+        let new_spec_path = path_from_name(test_dir.path(), "spec");
         fs::copy("tests/spec/json", &new_spec_path).unwrap();
 
         let mut spec_file = OpenOptions::new()
@@ -532,17 +555,14 @@ mod tests {
         });
 
         file.assert_matches_output();
-
-        //teardown
-        fs::remove_dir_all(&temp_dir).unwrap();
     }
 
     #[test]
     fn test_clear_tracking_file() {
         //setup
-        let temp_dir = create_temp_dir();
+        let test_dir = TestDir::new();
 
-        let file = TestableFile::new("json_simple".to_string(), &temp_dir);
+        let file = TestableFile::new("json_simple".to_string(), &test_dir);
         let temp_path = file.copy_to_temp();
 
         parallel!({
@@ -562,17 +582,14 @@ mod tests {
         });
 
         file.assert_matches_output();
-
-        //teardown
-        fs::remove_dir_all(&temp_dir).unwrap();
     }
 
     #[test]
     fn test_clear_tracking_dir() {
         //setup
-        let temp_dir = create_temp_dir();
+        let test_dir = TestDir::new();
 
-        let file = TestableFile::new("json_simple".to_string(), &temp_dir);
+        let file = TestableFile::new("json_simple".to_string(), &test_dir);
         let temp_path = file.copy_to_temp();
 
         parallel!({
@@ -581,7 +598,7 @@ mod tests {
 
         //exercise
         parallel!({
-            cli::run(vec![EXECUTABLE, "forget", &temp_dir]);
+            cli::run(vec![EXECUTABLE, "forget", test_dir.path_str()]);
         });
 
         //verify
@@ -592,9 +609,6 @@ mod tests {
         });
 
         file.assert_matches_output();
-
-        //teardown
-        fs::remove_dir_all(&temp_dir).unwrap();
     }
 
     #[test]
@@ -613,9 +627,9 @@ mod tests {
     #[test]
     fn test_no_skip() {
         //setup
-        let temp_dir = create_temp_dir();
+        let test_dir = TestDir::new();
 
-        let file = TestableFile::new("json_simple".to_string(), &temp_dir);
+        let file = TestableFile::new("json_simple".to_string(), &test_dir);
         let temp_path = file.copy_to_temp();
 
         parallel!({
@@ -637,17 +651,14 @@ mod tests {
         });
 
         file.assert_matches_output();
-
-        //teardown
-        fs::remove_dir_all(&temp_dir).unwrap();
     }
 
     #[test]
     fn test_no_track() {
         //setup
-        let temp_dir = create_temp_dir();
+        let test_dir = TestDir::new();
 
-        let file = TestableFile::new("json_simple".to_string(), &temp_dir);
+        let file = TestableFile::new("json_simple".to_string(), &test_dir);
         let temp_path = file.copy_to_temp();
 
         //exercise
@@ -670,17 +681,14 @@ mod tests {
         });
 
         file.assert_matches_output();
-
-        //teardown
-        fs::remove_dir_all(&temp_dir).unwrap();
     }
 
     #[test]
     fn test_no_write() {
         //setup
-        let temp_dir = create_temp_dir();
+        let mut test_dir = TestDir::new();
 
-        let file = TestableFile::new("json_simple".to_string(), &temp_dir);
+        let file = TestableFile::new("json_simple".to_string(), &test_dir);
         let temp_path = file.copy_to_temp();
 
         //exercise/verify
@@ -697,16 +705,16 @@ mod tests {
             });
         });
 
-        //teardown
-        fs::remove_dir_all(&temp_dir).unwrap();
+        // Prevent early destruction of test directory.
+        test_dir.release();
     }
 
     #[test]
     fn test_log_to_file_new() {
         //setup
-        let temp_dir = create_temp_dir();
+        let test_dir = TestDir::new();
 
-        let file = TestableFile::new("json_simple".to_string(), &temp_dir);
+        let file = TestableFile::new("json_simple".to_string(), &test_dir);
         let temp_path = file.copy_to_temp();
 
         serial!({
@@ -734,16 +742,14 @@ mod tests {
             log::set_max_level(LevelFilter::Off);
             let _ = fs::remove_file(&&*LOG_PATH);
         });
-
-        fs::remove_dir_all(&temp_dir).unwrap();
     }
 
     #[test]
     fn test_log_to_file_existing() {
         //setup
-        let temp_dir = create_temp_dir();
+        let test_dir = TestDir::new();
 
-        let file = TestableFile::new("json_simple".to_string(), &temp_dir);
+        let file = TestableFile::new("json_simple".to_string(), &test_dir);
         let temp_path = file.copy_to_temp();
 
         serial!({
@@ -772,14 +778,12 @@ mod tests {
             log::set_max_level(LevelFilter::Off);
             let _ = fs::remove_file(&&*LOG_PATH);
         });
-
-        fs::remove_dir_all(&temp_dir).unwrap();
     }
 
     #[test]
     fn test_set_log_level() {
         //setup
-        let temp_dir = create_temp_dir();
+        let test_dir = TestDir::new();
 
         let levels = vec!["trace", "debug", "info", "warn", "error"];
 
@@ -797,7 +801,7 @@ mod tests {
                     "fmt",
                     "tests/spec/json",
                     "-t",
-                    &temp_dir,
+                    test_dir.path_str(),
                 ]);
 
                 trace!("");
@@ -835,14 +839,12 @@ mod tests {
             log::set_max_level(LevelFilter::Off);
             let _ = fs::remove_file(&&*LOG_PATH);
         });
-
-        fs::remove_dir_all(&temp_dir).unwrap();
     }
 
     #[test]
     fn test_default_log_level() {
         //setup
-        let temp_dir = create_temp_dir();
+        let test_dir = TestDir::new();
 
         serial!({
             let _ = fs::remove_file(&&*LOG_PATH);
@@ -855,7 +857,7 @@ mod tests {
                 "fmt",
                 "tests/spec/json",
                 "-t",
-                &temp_dir,
+                test_dir.path_str(),
             ]);
 
             trace!("");
@@ -873,8 +875,6 @@ mod tests {
             log::set_max_level(LevelFilter::Off);
             let _ = fs::remove_file(&&*LOG_PATH);
         });
-
-        fs::remove_dir_all(&temp_dir).unwrap();
     }
 
     #[test]
@@ -903,9 +903,9 @@ mod tests {
     #[test]
     fn test_formatting_passed() {
         //setup
-        let temp_dir = create_temp_dir();
+        let test_dir = TestDir::new();
 
-        let file = TestableFile::new("json_simple".to_string(), &temp_dir);
+        let file = TestableFile::new("json_simple".to_string(), &test_dir);
         let temp_path = file.copy_to_temp();
 
         serial!({
@@ -943,17 +943,15 @@ mod tests {
             log::set_max_level(LevelFilter::Off);
             let _ = fs::remove_file(&&*LOG_PATH);
         });
-
-        fs::remove_dir_all(&temp_dir).unwrap();
     }
 
     #[test]
     fn test_formatting_failed() {
         //setup
-        let temp_dir = create_temp_dir();
+        let test_dir = TestDir::new();
         let _ = fs::remove_file(&&*LOG_PATH);
 
-        let file = TestableFile::new("java8_simple".to_string(), &temp_dir);
+        let file = TestableFile::new("java8_simple".to_string(), &test_dir);
         let temp_path = file.copy_to_temp();
 
         serial!({
@@ -994,16 +992,14 @@ mod tests {
             log::set_max_level(LevelFilter::Off);
             let _ = fs::remove_file(&&*LOG_PATH);
         });
-
-        fs::remove_dir_all(&temp_dir).unwrap();
     }
 
     #[test]
     fn test_formatting_unchanged() {
         //setup
-        let temp_dir = create_temp_dir();
+        let test_dir = TestDir::new();
 
-        let file = TestableFile::new("json_simple".to_string(), &temp_dir);
+        let file = TestableFile::new("json_simple".to_string(), &test_dir);
         let temp_path = file.copy_to_temp();
 
         serial!({
@@ -1040,16 +1036,14 @@ mod tests {
             log::set_max_level(LevelFilter::Off);
             let _ = fs::remove_file(&&*LOG_PATH);
         });
-
-        fs::remove_dir_all(&temp_dir).unwrap();
     }
 
     #[test]
     fn test_check_formatting_ok() {
         //setup
-        let temp_dir = create_temp_dir();
+        let test_dir = TestDir::new();
 
-        let file = TestableFile::new("json_simple".to_string(), &temp_dir);
+        let file = TestableFile::new("json_simple".to_string(), &test_dir);
         let temp_path = file.copy_to_temp();
 
         serial!({
@@ -1086,16 +1080,14 @@ mod tests {
             log::set_max_level(LevelFilter::Off);
             let _ = fs::remove_file(&&*LOG_PATH);
         });
-
-        fs::remove_dir_all(&temp_dir).unwrap();
     }
 
     #[test]
     fn test_check_formatting_failed() {
         //setup
-        let temp_dir = create_temp_dir();
+        let test_dir = TestDir::new();
 
-        let file = TestableFile::new("json_simple".to_string(), &temp_dir);
+        let file = TestableFile::new("json_simple".to_string(), &test_dir);
         let temp_path = file.copy_to_temp();
 
         serial!({
@@ -1142,16 +1134,14 @@ mod tests {
             log::set_max_level(LevelFilter::Off);
             let _ = fs::remove_file(&&*LOG_PATH);
         });
-
-        fs::remove_dir_all(&temp_dir).unwrap();
     }
 
     #[test]
     fn test_check_formatting_error() {
         //setup
-        let temp_dir = create_temp_dir();
+        let test_dir = TestDir::new();
 
-        let file = TestableFile::new("java8_simple".to_string(), &temp_dir);
+        let file = TestableFile::new("java8_simple".to_string(), &test_dir);
         let temp_path = file.copy_to_temp();
 
         serial!({
@@ -1203,8 +1193,6 @@ mod tests {
             log::set_max_level(LevelFilter::Off);
             let _ = fs::remove_file(&&*LOG_PATH);
         });
-
-        fs::remove_dir_all(&temp_dir).unwrap();
     }
 
     #[test]
@@ -1318,9 +1306,9 @@ mod tests {
     #[test]
     fn test_execute_on_server() {
         //setup
-        let temp_dir = create_temp_dir();
+        let test_dir = TestDir::new();
 
-        let file = TestableFile::new("json_simple".to_string(), &temp_dir);
+        let file = TestableFile::new("json_simple".to_string(), &test_dir);
         let temp_path = file.copy_to_temp();
 
         serial!({
@@ -1355,9 +1343,6 @@ mod tests {
 
         //verify
         file.assert_matches_output();
-
-        //teardown
-        fs::remove_dir_all(&temp_dir).unwrap();
     }
 
     #[test]
@@ -1468,9 +1453,9 @@ mod tests {
     #[test]
     fn test_format_via_daemon() {
         //setup
-        let temp_dir = create_temp_dir();
+        let test_dir = TestDir::new();
 
-        let file = TestableFile::new("json_simple".to_string(), &temp_dir);
+        let file = TestableFile::new("json_simple".to_string(), &test_dir);
         let temp_path = file.copy_to_temp();
 
         serial!({
@@ -1500,17 +1485,14 @@ mod tests {
 
         //verify
         file.assert_matches_output();
-
-        //teardown
-        fs::remove_dir_all(&temp_dir).unwrap();
     }
 
     #[test]
     fn test_cache_fjr() {
         //setup
-        let temp_dir = create_temp_dir();
+        let test_dir = TestDir::new();
 
-        let file = TestableFile::new("balanced_brackets".to_string(), &temp_dir);
+        let file = TestableFile::new("balanced_brackets".to_string(), &test_dir);
         let temp_path = file.copy_to_temp();
 
         serial!({
@@ -1547,27 +1529,24 @@ mod tests {
 
         //verify
         file.assert_matches_output();
-
-        //teardown
-        fs::remove_dir_all(&temp_dir).unwrap();
     }
 
     #[test]
     fn test_pwd_shorthand() {
         //setup
-        let temp_dir1 = create_temp_dir();
-        let file1 = TestableFile::new("balanced_brackets".to_string(), &temp_dir1);
+        let test_dir1 = TestDir::new();
+        let file1 = TestableFile::new("balanced_brackets".to_string(), &test_dir1);
         file1.copy_to_temp();
 
-        let temp_dir2 = create_temp_dir();
-        let file2 = TestableFile::new("balanced_brackets".to_string(), &temp_dir2);
+        let test_dir2 = TestDir::new();
+        let file2 = TestableFile::new("balanced_brackets".to_string(), &test_dir2);
         file2.copy_to_temp();
 
         let usr_dir = env::current_dir().unwrap();
-        env::set_current_dir(&temp_dir1).unwrap();
+        env::set_current_dir(test_dir1.path()).unwrap();
 
+        //exercise
         parallel!({
-            //exercise
             cli::run(vec![
                 &format!("../../{}", EXECUTABLE),
                 "fmt",
@@ -1581,10 +1560,6 @@ mod tests {
         env::set_current_dir(&usr_dir).unwrap();
         file1.assert_matches_output();
         file2.assert_does_not_match_output();
-
-        //teardown
-        fs::remove_dir_all(&temp_dir1).unwrap();
-        fs::remove_dir_all(&temp_dir2).unwrap();
     }
 
     fn assert_modifies_file(file_path: &str, modifier: &Fn()) {
@@ -1603,12 +1578,6 @@ mod tests {
         let finally_modified_at = Path::new(file_path).metadata().unwrap().modified().unwrap();
 
         initially_modified_at != finally_modified_at
-    }
-
-    fn create_temp_dir() -> String {
-        let temp_dir = format!("tests/temp-{}", Uuid::new_v4().to_string());
-        fs::create_dir(&temp_dir).unwrap();
-        temp_dir
     }
 
     fn read_to_string(path: &Path) -> String {


### PR DESCRIPTION
- Use RAII for temporary directories, so that files are cleaned up in the event of a panic.
- Create test files immediately during construction.