### PR TITLE
Add index docs page as README

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1 +1,1 @@
-# padd
+../README.md


### PR DESCRIPTION
Use the repo README as the index page for the docs website. This is done using a symbolic link, so both files do not need to be maintained separately.